### PR TITLE
Improve error handling for Kostal Plenticore

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -50,11 +50,10 @@ func pf(format string, v ...interface{}) {
 
 func scanSunspec(client modbus.Client) {
 	in, err := bus.Open(client)
-	if err != nil {
-		if in == nil {
-			log.Fatal(err)
-		}
-		log.Printf("warning: device opened with partial result: %v", err)
+	if err != nil && in == nil {
+		log.Fatal(err)
+	} else if err != nil {
+		log.Printf("warning: device opened with partial result: %v", err) // log error but continue
 	}
 
 	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -77,9 +77,11 @@ SCAN:
 		conn.Slave(uint8(deviceID))
 
 		for _, dev := range devices {
-			err := dev.Initialize(client)
-			if err != nil {
-				continue // devices
+			if err := dev.Initialize(client); err != nil {
+				if _, partial := err.(meters.SunSpecPartiallyInitialized); !partial {
+					continue // devices
+				}
+				log.Println(err) // log error but continue
 			}
 
 			mr, err := dev.Probe(client)

--- a/meters/device.go
+++ b/meters/device.go
@@ -4,6 +4,12 @@ import (
 	"github.com/grid-x/modbus"
 )
 
+// SunSpecPartiallyInitialized indicates error during device initialization.
+// The sunspec device's model tree may be incomplete.
+type SunSpecPartiallyInitialized interface {
+	PartiallyInitialized()
+}
+
 // DeviceDescriptor describes a device
 type DeviceDescriptor struct {
 	Manufacturer string

--- a/server/handler.go
+++ b/server/handler.go
@@ -84,9 +84,12 @@ func (h *Handler) initializeDevice(
 	uniqueID := h.uniqueID(id, dev)
 
 	if err := dev.Initialize(h.Manager.Conn.ModbusClient()); err != nil {
-		log.Printf("initializing device %s failed: %v", uniqueID, err)
-		sleepIsCancelled(ctx, initDelay)
-		return nil, err
+		if _, partial := err.(meters.SunSpecPartiallyInitialized); !partial {
+			log.Printf("initializing device %s failed: %v", uniqueID, err)
+			sleepIsCancelled(ctx, initDelay)
+			return nil, err
+		}
+		log.Println(err) // log error but continue
 	}
 
 	d := dev.Descriptor()


### PR DESCRIPTION
This PR refactors error logging out of the device into the calling commands.