### PR TITLE
Make broadcaster operate on empty interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: xenial
 
 language: go
 go:
-  - "1.12"
+  - "1.13"
 go_import_path: github.com/volkszaehler/mbmd
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Precompiled release packages are [available](https://github.com/volkszaehler/mbm
 
 ### Building from source
 
-`mbmd` is developed in [Go](http://golang.org) and requires >=1.12. To build from source two steps are needed:
+`mbmd` is developed in [Go](http://golang.org) and requires >=1.13. To build from source two steps are needed:
 
 - use `make install` to install the build tools (make sure `$GOPATH/bin` is part of the path to make the installed tools accessible for the next step)
 - then run `make build` which creates the `./mbmd` binary

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -287,8 +287,8 @@ func run(cmd *cobra.Command, args []string) {
 				viper.GetString("mqtt.clientid"),
 				viper.GetBool("mqtt.clean"),
 			)
-			// _ = server.ToControlChannel(teeC.Attach())
-			homieRunner := server.NewHomieRunner(qe, options, qos, topic, verbose)
+			cc := server.ToControlChannel(teeC.Attach())
+			homieRunner := server.NewHomieRunner(qe, cc, options, qos, topic, verbose)
 			tee.AttachRunner(server.NewSnipRunner(homieRunner.Run))
 		}
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -230,26 +230,30 @@ func run(cmd *cobra.Command, args []string) {
 	// query engine
 	qe := server.NewQueryEngine(confHandler.Managers)
 
-	// result channels
+	// results- and control channels
 	rc := make(chan server.QuerySnip)
 	cc := make(chan server.ControlSnip)
 
 	// tee that broadcasts meter messages to multiple recipients
-	tee := server.NewQuerySnipBroadcaster(rc)
+	tee := server.NewBroadcaster(server.FromSnipChannel(rc))
 	go tee.Run()
 
+	// tee that broadcasts control messages to multiple recipients
+	teeC := server.NewBroadcaster(server.FromControlChannel(cc))
+	go teeC.Run()
+
 	// status cache (always needed to consume control messages)
-	status := server.NewStatus(qe, cc)
+	status := server.NewStatus(qe, server.ToControlChannel(teeC.Attach()))
 
 	// web server
 	if viper.GetString("api") != "" {
 		// measurement cache for REST api
 		cache := server.NewCache(cacheDuration, status, viper.GetBool("verbose"))
-		tee.AttachRunner(cache.Run)
+		tee.AttachRunner(server.NewSnipRunner(cache.Run))
 
 		// websocket hub
 		hub := server.NewSocketHub(status)
-		tee.AttachRunner(hub.Run)
+		tee.AttachRunner(server.NewSnipRunner(hub.Run))
 
 		// http daemon
 		httpd := server.NewHttpd(qe, cache)
@@ -271,11 +275,11 @@ func run(cmd *cobra.Command, args []string) {
 				viper.GetBool("mqtt.clean"),
 			)
 			mqttRunner := server.NewMqttRunner(options, qos, topic, verbose)
-			tee.AttachRunner(mqttRunner.Run)
+			tee.AttachRunner(server.NewSnipRunner(mqttRunner.Run))
 		}
 
 		// homie runner
-		if viper.GetString("mqtt.homie") != "" {
+		if topic := viper.GetString("mqtt.homie"); topic != "" {
 			options := server.NewMqttOptions(
 				viper.GetString("mqtt.broker"),
 				viper.GetString("mqtt.user"),
@@ -283,8 +287,9 @@ func run(cmd *cobra.Command, args []string) {
 				viper.GetString("mqtt.clientid"),
 				viper.GetBool("mqtt.clean"),
 			)
-			homieRunner := server.NewHomieRunner(options, qos, qe, viper.GetString("mqtt.homie"), verbose)
-			tee.AttachRunner(homieRunner.Run)
+			// _ = server.ToControlChannel(teeC.Attach())
+			homieRunner := server.NewHomieRunner(qe, options, qos, topic, verbose)
+			tee.AttachRunner(server.NewSnipRunner(homieRunner.Run))
 		}
 	}
 
@@ -301,7 +306,7 @@ func run(cmd *cobra.Command, args []string) {
 			viper.GetBool("verbose"),
 		)
 
-		tee.AttachRunner(influx.Run)
+		tee.AttachRunner(server.NewSnipRunner(influx.Run))
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/go.mod
+++ b/go.mod
@@ -32,3 +32,5 @@ require (
 )
 
 replace github.com/crabmusket/gosunspec => github.com/andig/gosunspec v0.0.0-20190812065825-447c0884e0a9
+
+go 1.13

--- a/server/handler.go
+++ b/server/handler.go
@@ -123,6 +123,13 @@ func (h *Handler) queryDevice(
 		measurements, err := dev.Query(h.Manager.Conn.ModbusClient())
 
 		if err == nil {
+			// send ok status
+			status.Available(true)
+			control <- ControlSnip{
+				Device: uniqueID,
+				Status: *status,
+			}
+
 			// send measurements
 			for _, r := range measurements {
 				snip := QuerySnip{
@@ -130,14 +137,6 @@ func (h *Handler) queryDevice(
 					MeasurementResult: r,
 				}
 				results <- snip
-			}
-
-			// send ok
-			status.Available(true)
-
-			control <- ControlSnip{
-				Device: uniqueID,
-				Status: *status,
 			}
 
 			return
@@ -154,6 +153,8 @@ func (h *Handler) queryDevice(
 
 	// close connection to force modbus client to reopen
 	h.Manager.Conn.Close()
+
+	// send error status
 	status.Available(false)
 	control <- ControlSnip{
 		Device: uniqueID,

--- a/server/homie.go
+++ b/server/homie.go
@@ -26,6 +26,7 @@ type HomieRunner struct {
 	verbose   bool
 	rootTopic string
 	qe        DeviceInfo
+	cc        <-chan ControlSnip
 	meters    map[string]*homieMeter
 }
 
@@ -33,17 +34,19 @@ type homieMeter struct {
 	*MqttClient
 	rootTopic string
 	meter     string
+	online    bool
 	observed  map[meters.Measurement]bool
 }
 
 // NewHomieRunner create new runner for homie IoT spec
-func NewHomieRunner(qe DeviceInfo, options *MQTT.ClientOptions, qos byte, rootTopic string, verbose bool) *HomieRunner {
+func NewHomieRunner(qe DeviceInfo, cc <-chan ControlSnip, options *MQTT.ClientOptions, qos byte, rootTopic string, verbose bool) *HomieRunner {
 	hr := &HomieRunner{
 		options:   options,
 		qos:       qos,
 		verbose:   verbose,
 		rootTopic: rootTopic,
 		qe:        qe,
+		cc:        cc,
 		meters:    make(map[string]*homieMeter),
 	}
 
@@ -71,32 +74,47 @@ func (hr *HomieRunner) cloneOptions() *MQTT.ClientOptions {
 func (hr *HomieRunner) Run(in <-chan QuerySnip) {
 	defer hr.unregister() // cleanup topics
 
-	for snip := range in {
-		meter, ok := hr.meters[snip.Device]
-
-		// first time - publish meter
-		if !ok {
-			// new client with unique id
-			options := hr.cloneOptions()
-			clientID := fmt.Sprintf("%s-%s", options.ClientID, mqttDeviceTopic(snip.Device))
-			options.SetClientID(clientID)
-
-			lwt := fmt.Sprintf("%s/%s/$state", hr.rootTopic, mqttDeviceTopic(snip.Device))
-			options.SetWill(lwt, "lost", hr.qos, true)
-
-			client := NewMqttClient(options, hr.qos, hr.verbose)
-
-			// add meter and publish
-			meter = newHomieMeter(client, hr.rootTopic, snip.Device)
-			hr.meters[snip.Device] = meter
-
-			d := hr.qe.DeviceDescriptorByID(snip.Device)
-			meter.publishMeter(d)
+	for {
+		select {
+		case snip, ok := <-in:
+			if !ok {
+				return // channel closed
+			}
+			hr.publish(snip)
+		case snip := <-hr.cc:
+			if meter, ok := hr.meters[snip.Device]; ok {
+				meter.status(snip.Status.Online)
+			}
 		}
-
-		// publish actual message
-		meter.publishMessage(snip)
 	}
+}
+
+// unregister unpublishes device information
+func (hr *HomieRunner) publish(snip QuerySnip) {
+	meter, ok := hr.meters[snip.Device]
+
+	// first time - publish meter
+	if !ok {
+		// new client with unique id
+		options := hr.cloneOptions()
+		clientID := fmt.Sprintf("%s-%s", options.ClientID, mqttDeviceTopic(snip.Device))
+		options.SetClientID(clientID)
+
+		lwt := fmt.Sprintf("%s/%s/$state", hr.rootTopic, mqttDeviceTopic(snip.Device))
+		options.SetWill(lwt, "lost", hr.qos, true)
+
+		client := NewMqttClient(options, hr.qos, hr.verbose)
+
+		// add meter and publish
+		meter = newHomieMeter(client, hr.rootTopic, snip.Device)
+		hr.meters[snip.Device] = meter
+
+		d := hr.qe.DeviceDescriptorByID(snip.Device)
+		meter.publishMeter(d)
+	}
+
+	// publish actual message
+	meter.publishMessage(snip)
 }
 
 // unregister unpublishes device information
@@ -106,6 +124,7 @@ func (hr *HomieRunner) unregister() {
 	}
 }
 
+// newHomieMeter creates meter on given mqtt client
 func newHomieMeter(client *MqttClient, rootTopic string, meter string) *homieMeter {
 	hm := &homieMeter{
 		MqttClient: client,
@@ -120,6 +139,7 @@ func newHomieMeter(client *MqttClient, rootTopic string, meter string) *homieMet
 func (hr *homieMeter) unregister() {
 	subTopic := mqttDeviceTopic(hr.meter)
 	hr.publish(subTopic+"/$state", "disconnected")
+	hr.MqttClient.Client.Disconnect(uint(timeout.Milliseconds()))
 }
 
 func (hr *homieMeter) publishMeter(descriptor meters.DeviceDescriptor) {
@@ -128,7 +148,7 @@ func (hr *homieMeter) publishMeter(descriptor meters.DeviceDescriptor) {
 	// device
 	hr.publish(subTopic+"/$homie", specVersion)
 	hr.publish(subTopic+"/$name", "MBMD")
-	hr.publish(subTopic+"/$state", "ready")
+	hr.publish(subTopic+"/$state", "init")
 
 	// node
 	hr.publish(subTopic+"/$nodes", nodeTopic)
@@ -137,6 +157,19 @@ func (hr *homieMeter) publishMeter(descriptor meters.DeviceDescriptor) {
 	subTopic = fmt.Sprintf("%s/%s", subTopic, nodeTopic)
 	hr.publish(subTopic+"/$name", descriptor.Manufacturer)
 	hr.publish(subTopic+"/$type", descriptor.Model)
+}
+
+// status updates a meter's $state attibute when its online status changes
+func (hr *homieMeter) status(online bool) {
+	if hr.online != online {
+		subTopic := mqttDeviceTopic(hr.meter)
+		msg := "alert"
+		if online {
+			msg = "ready"
+		}
+		hr.publish(subTopic+"/$state", msg)
+		hr.online = online
+	}
 }
 
 func (hr *homieMeter) publishMessage(snip QuerySnip) {

--- a/server/homie.go
+++ b/server/homie.go
@@ -37,7 +37,7 @@ type homieMeter struct {
 }
 
 // NewHomieRunner create new runner for homie IoT spec
-func NewHomieRunner(options *MQTT.ClientOptions, qos byte, qe DeviceInfo, rootTopic string, verbose bool) *HomieRunner {
+func NewHomieRunner(qe DeviceInfo, options *MQTT.ClientOptions, qos byte, rootTopic string, verbose bool) *HomieRunner {
 	hr := &HomieRunner{
 		options:   options,
 		qos:       qos,

--- a/server/mqtt.go
+++ b/server/mqtt.go
@@ -67,7 +67,7 @@ func (m *MqttClient) Publish(topic string, retained bool, message interface{}) {
 	if m.verbose {
 		log.Printf("mqtt: publish %s, message: %s", topic, message)
 	}
-	m.WaitForToken(token)
+	go m.WaitForToken(token)
 }
 
 // WaitForToken synchronously waits until token operation completed


### PR DESCRIPTION
This PR restructures the Homie device handling:

- full lifecycle support
- reflect modbus errors in homie device `$state`
- convert snip broadcaster to generic structure and add adapters