### PR TITLE
Validate config file

### DIFF
--- a/cmd/confighandler.go
+++ b/cmd/confighandler.go
@@ -15,10 +15,39 @@ import (
 
 // Config describes the entire configuration
 type Config struct {
-	API      string
-	Mqtt     MqttConfig
-	Adapters []AdapterConfig
-	Devices  []DeviceConfig
+	commandLine `mapstructure:",squash"` // for completeness
+	API         string
+	Mqtt        MqttConfig
+	Adapters    []AdapterConfig
+	Devices     []DeviceConfig
+}
+
+// commandLine areguments are embedded into Config to allow validating
+// surplus keys in config file
+type commandLine struct {
+	Adapter           interface{} `mapstructure:"adapter"`
+	Baudrate          interface{} `mapstructure:"baudrate"`
+	Comset            interface{} `mapstructure:"comset"`
+	Config            interface{} `mapstructure:"config"`
+	Help              interface{} `mapstructure:"help"`
+	Influx            interface{} `mapstructure:"influx"`
+	InfluxDatabase    interface{} `mapstructure:"influx-database"`
+	InfluxInterval    interface{} `mapstructure:"influx-interval"`
+	InfluxMeasurement interface{} `mapstructure:"influx-measurement"`
+	InfluxPassword    interface{} `mapstructure:"influx-password"`
+	InfluxPrecision   interface{} `mapstructure:"influx-precision"`
+	InfluxURL         interface{} `mapstructure:"influx-url"`
+	InfluxUser        interface{} `mapstructure:"influx-user"`
+	MqttBroker        interface{} `mapstructure:"mqtt-broker"`
+	MqttClean         interface{} `mapstructure:"mqtt-clean"`
+	MqttClientID      interface{} `mapstructure:"mqtt-clientid"`
+	MqttHomie         interface{} `mapstructure:"mqtt-homie"`
+	MqttPassword      interface{} `mapstructure:"mqtt-password"`
+	MqttQos           interface{} `mapstructure:"mqtt-qos"`
+	MqttTopic         interface{} `mapstructure:"mqtt-topic"`
+	MqttUser          interface{} `mapstructure:"mqtt-user"`
+	Raw               interface{} `mapstructure:"raw"`
+	Verbose           interface{} `mapstructure:"verbose"`
 }
 
 // MqttConfig describes the mqtt broker configuration

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -198,8 +198,8 @@ func run(cmd *cobra.Command, args []string) {
 		log.Printf("config: using %s", viper.ConfigFileUsed())
 
 		var conf Config
-		if err := viper.Unmarshal(&conf); err != nil {
-			log.Fatalf("failed parsing config file: %v", err)
+		if err := viper.GetViper().UnmarshalExact(&conf); err != nil {
+			log.Fatalf("config: failed parsing config file %s: %v", cfgFile, err)
 		}
 
 		// create devices from config file only if not overridden on command line


### PR DESCRIPTION
With this PR, excessive config keys result in an error, e.g.:

```
2019/11/18 13:16:21 config: failed parsing config file /Users/andig/htdocs/mbmd/mbmd.yaml: 1 error(s) decoding:

* 'Devices[0]' has invalid keys: name2
exit status 1
```