### PR TITLE
Add default idle timeout

### DIFF
--- a/meters/tcp.go
+++ b/meters/tcp.go
@@ -19,6 +19,7 @@ func NewTCPClientHandler(device string) *modbus.TCPClientHandler {
 
 	// set default timings
 	handler.Timeout = 1 * time.Second
+	handler.IdleTimeout = 5 * time.Second
 	handler.ProtocolRecoveryTimeout = 10 * time.Second
 	handler.LinkRecoveryTimeout = 15 * time.Second
 


### PR DESCRIPTION
Drop TCP connection when idle. Helps e.g. with some grid inverters where the TCP stack can only handle a limited number of connections. 