### PR TITLE
workaround to fix Total Export Energy readings for KOSTAL devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ this as the meter ID.
 - **SBC ALE3**: This compact Saia Burgess Controls meter is comparable to the SDM630.
 It has two tariffs, both import and export depending on meter version and compact (4TE). It's often used with Viessmann heat pumps.
 - **BE MPM3PM**: Compact (4TE) three phase meter.
-- **KOSTAL Smart Energy Meter**: Slave device for Kostal grid inverters. Known [bug](https://github.com/volkszaehler/mbmd/pull/61#issuecomment-570081618) in inverter firmware with Total Export Energy.
+- **KOSTAL Smart Energy Meter**: Slave device for Kostal grid inverters.
 
 ## Modbus TCP Grid Inverters
 

--- a/meters/sunspec/models.go
+++ b/meters/sunspec/models.go
@@ -120,6 +120,13 @@ var modelMap = map[sunspec.ModelId]map[int]map[string]meters.Measurement{
 	},
 }
 
+var negativeMap = map[meters.Measurement]bool{
+	meters.Export:     true,
+	meters.ExportL1:   true,
+	meters.ExportL2:   true,
+	meters.ExportL3:   true,
+}
+
 var dividerMap = map[meters.Measurement]float64{
 	meters.Export:     1000,
 	meters.ExportL1:   1000,

--- a/meters/sunspec/sunspec.go
+++ b/meters/sunspec/sunspec.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"time"
+	"encoding/binary"
 
 	sunspec "github.com/andig/gosunspec"
 	sunspecbus "github.com/andig/gosunspec/modbus"
@@ -184,6 +185,12 @@ func (d *sunSpec) convertPoint(b sunspec.Block, blockID int, pointID string, m m
 		return meters.MeasurementResult{}, errors.New("NaN value")
 	}
 
+	// apply fix for invalid negativ values
+	if val, exists := negativeMap[m]; exists && val {
+		buf := make([]byte, 4)
+		binary.BigEndian.PutUint32(buf[0:], uint32(v))
+		v = math.Abs(float64(int32(binary.BigEndian.Uint32(buf[0:]))))
+	}
 	// apply scale factor for energy
 	if div, ok := dividerMap[m]; ok {
 		v /= div


### PR DESCRIPTION
Fix Kostal Smart Energy Meter treating TotWhExp as Int64 instead of Acc32.