### PR TITLE
Use hierarchical topic names for lines, strings and tariffs

### DIFF
--- a/server/queryengine.go
+++ b/server/queryengine.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// deviceIDregex is the regex pattern that identifies valid device ids
-	deviceIDregex = "\\w*(\\d+)\\.(\\d+)"
+	deviceIDregex = `\w*(\d+)\.(\d+)`
 )
 
 // DeviceInfo returns device descriptor by device id


### PR DESCRIPTION
**Breaking Change**: This PR provides better support for MQTT wildcards. Since MQTT has no other wildcard characters than `#` and `+`, this pr will convert mqtt topics like `mbmd/sdm1-1/PowerL1` to `mbmd/sdm1-1/Power/L1`, same for inverter strings and tariffs. 

Reason for this breaking change is that it will allow to listen for anything related to Power like `mbmd/sdm1-1/Power`, the lines like `mbmd/sdm1-1/Power/#` or any line or string data as `mbmd/sdm1-1/#/#`. 

Potential further enhancement might be to duplicate this procedure for the Import/Export Active/Reactive components- please let me know if needed.