### PR TITLE
Don't break when no home directory can be found

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -88,15 +88,11 @@ func initConfig() {
 		// Use config file from the flag
 		viper.SetConfigFile(cfgFile)
 	} else {
-		// Find home directory
-		home, err := os.UserHomeDir()
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+		// search for config in home directory if available
+		if home, err := os.UserHomeDir(); err == nil {
+			viper.AddConfigPath(home)
 		}
 
-		// Search config in home directory with name "mbmd" (without extension).
-		viper.AddConfigPath(home)
 		viper.AddConfigPath(".")    // optionally look for config in the working directory
 		viper.AddConfigPath("/etc") // path to look for the config file in
 


### PR DESCRIPTION
The systemd example provided in the readme cannot run because mbmd refuses to start when it's unable to figure out a home directory. 

```
pi@powermeter:~ $ journalctl -u mbmd.service 
-- Logs begin at Sun 2020-03-22 23:45:11 GMT, end at Mon 2020-03-23 09:37:22 GMT. --
Mar 23 09:37:16 powermeter systemd[1]: Started mbmd.
Mar 23 09:37:16 powermeter mbmd[898]: $HOME is not defined
Mar 23 09:37:16 powermeter systemd[1]: mbmd.service: Main process exited, code=exited, status=1/FAILURE
Mar 23 09:37:16 powermeter systemd[1]: mbmd.service: Failed with result 'exit-code'.
Mar 23 09:37:17 powermeter systemd[1]: mbmd.service: Service RestartSec=100ms expired, scheduling restart.
Mar 23 09:37:17 powermeter systemd[1]: mbmd.service: Scheduled restart job, restart counter is at 1.
Mar 23 09:37:17 powermeter systemd[1]: Stopped mbmd.
```

This pull request adds the home directory if it can be determined, otherwise continues without it.
