### PR TITLE
Workaround KOSTAL incorrectly using negative values for Acc32/64

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/volkszaehler/mbmd/meters"
+	quirks "github.com/volkszaehler/mbmd/meters/sunspec"
 
 	sunspec "github.com/andig/gosunspec"
 	bus "github.com/andig/gosunspec/modbus"
@@ -85,7 +86,11 @@ func scanSunspec(client modbus.Client) {
 					if p.NotImplemented() {
 						v = "n/a"
 					} else if t == "int" || t == "uin" || t == "acc" {
-						v = fmt.Sprintf("%.2f", p.ScaledValue())
+						// for time being, always to this
+						quirks.FixKostal(p)
+
+						v = p.ScaledValue()
+						v = fmt.Sprintf("%.2f", v)
 					}
 
 					vs := fmt.Sprintf("%17v", v)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/volkszaehler/mbmd
 
 require (
 	github.com/alvaroloes/enumer v1.1.2 // indirect
-	github.com/andig/gosunspec v0.0.0-20200112114436-368765cf4ec1
+	github.com/andig/gosunspec v0.0.0-20200429133549-3cf6a82fed9c
 	github.com/eclipse/paho.mqtt.golang v1.2.0
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/google/go-github v17.0.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/alvaroloes/enumer v1.1.2 h1:5khqHB33TZy1GWCO/lZwcroBFh7u+0j40T83VUbfA
 github.com/alvaroloes/enumer v1.1.2/go.mod h1:FxrjvuXoDAx9isTJrv4c+T410zFi0DtXIT0m65DJ+Wo=
 github.com/andig/gosunspec v0.0.0-20200112114436-368765cf4ec1 h1:Fe5Mw5GBsmi1lDsYfRsE++f/PDk0p+TdbR6iQhu1RlM=
 github.com/andig/gosunspec v0.0.0-20200112114436-368765cf4ec1/go.mod h1:YkshK8WMzYn1iXAZzHUO75gIqhMSan2ctgBVtBkRIyA=
+github.com/andig/gosunspec v0.0.0-20200429133549-3cf6a82fed9c h1:AMtX56iHlNYVxMID7fe9efuVtaxgtdjyMeolg7q87IE=
+github.com/andig/gosunspec v0.0.0-20200429133549-3cf6a82fed9c/go.mod h1:YkshK8WMzYn1iXAZzHUO75gIqhMSan2ctgBVtBkRIyA=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=


### PR DESCRIPTION
Replaces https://github.com/volkszaehler/mbmd/pull/97. At this time, we're applying this for *all* Kostal acc values.