### PR TITLE
Fix and document 32bit swapped readings

### DIFF
--- a/cmd/read.go
+++ b/cmd/read.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/volkszaehler/mbmd/meters"
+	"github.com/volkszaehler/mbmd/meters/rs485"
 )
 
 // readCmd represents the read command
@@ -87,11 +88,6 @@ func deviceIDFromSpec(meterDef string) uint8 {
 	return uint8(devID)
 }
 
-func bytes2uintSwapped(b []byte, length int) uint64 {
-	_ = b[3] // bounds check hint to compiler; see golang.org/issue/14808
-	return uint64(b[3])<<16 | uint64(b[2])<<24 | uint64(b[1]) | uint64(b[0])<<8
-}
-
 func bytes2uint(b []byte, length int) uint64 {
 	switch length {
 	case 1:
@@ -149,7 +145,7 @@ func decode(b []byte, length int, encoding string) string {
 		if length != 2 {
 			log.Fatal("Invalid length for int32(swapped) encoding")
 		}
-		u := bytes2uintSwapped(b, length)
+		u := rs485.BigEndianUint32Swapped(b)
 		return strconv.FormatInt(int64(int32(u)), 10)
 	case "uint":
 		u := bytes2uint(b, length)
@@ -158,7 +154,7 @@ func decode(b []byte, length int, encoding string) string {
 		if length != 2 {
 			log.Fatal("Invalid length for uint32(swapped) encoding")
 		}
-		u := bytes2uintSwapped(b, length)
+		u := rs485.BigEndianUint32Swapped(b)
 		return strconv.FormatUint(uint64(uint32(u)), 10)
 	case "hex":
 		return fmt.Sprintf("%02x", b)

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -42,7 +42,7 @@ func init() {
 	readCmd.PersistentFlags().StringP(
 		"encoding", "e",
 		"int",
-		"Data encoding: bit|int|uint|hex|float|string",
+		"Data encoding: bit|int|uint|int32s|uint32s|hex|float|string",
 	)
 }
 
@@ -145,15 +145,21 @@ func decode(b []byte, length int, encoding string) string {
 	case "int":
 		u := bytes2uint(b, length)
 		return strconv.FormatInt(int64(u), 10)
-	case "int32swapped":
+	case "int32swapped", "int32s":
 		if length != 2 {
-			log.Fatal("Invalid length for int32swapped encoding")
+			log.Fatal("Invalid length for int32(swapped) encoding")
 		}
 		u := bytes2uintSwapped(b, length)
-		return strconv.FormatInt(int64(u), 10)
+		return strconv.FormatInt(int64(int32(u)), 10)
 	case "uint":
 		u := bytes2uint(b, length)
 		return strconv.FormatUint(u, 10)
+	case "uint32swapped", "uint32s":
+		if length != 2 {
+			log.Fatal("Invalid length for uint32(swapped) encoding")
+		}
+		u := bytes2uintSwapped(b, length)
+		return strconv.FormatUint(uint64(uint32(u)), 10)
 	case "hex":
 		return fmt.Sprintf("%02x", b)
 	case "string":

--- a/docs/mbmd_read.md
+++ b/docs/mbmd_read.md
@@ -16,7 +16,7 @@ mbmd read [flags] register length
 
 ```
   -d, --device string     MODBUS device ID to query. Only single device allowed. (default "1")
-  -e, --encoding string   Data encoding: bit|int|uint|hex|float|string (default "int")
+  -e, --encoding string   Data encoding: bit|int|uint|int32s|uint32s|hex|float|string (default "int")
   -t, --type string       Register type to read: holding|input|coil|discrete (default "holding")
 ```
 

--- a/meters/rs485/transform.go
+++ b/meters/rs485/transform.go
@@ -5,6 +5,13 @@ import (
 	"math"
 )
 
+// BigEndianUint32Swapped converts bytes to uint32 wrapped as uint64 with swapped word order.
+// To use the result as int32 value make sure to convert to uint32 first before converting to int32.
+func BigEndianUint32Swapped(b []byte) uint64 {
+	_ = b[3] // bounds check hint to compiler; see golang.org/issue/14808
+	return uint64(b[3])<<16 | uint64(b[2])<<24 | uint64(b[1]) | uint64(b[0])<<8
+}
+
 // RTUTransform functions convert RTU bytes to meaningful data types.
 type RTUTransform func([]byte) float64
 
@@ -27,6 +34,12 @@ func RTUUint32ToFloat64(b []byte) float64 {
 	return float64(u)
 }
 
+// RTUUint32ToFloat64Swapped converts 32 bit unsigned integer readings with swapped word order
+func RTUUint32ToFloat64Swapped(b []byte) float64 {
+	u := uint32(BigEndianUint32Swapped(b))
+	return float64(u)
+}
+
 // RTUUint64ToFloat64 converts 64 bit unsigned integer readings
 func RTUUint64ToFloat64(b []byte) float64 {
 	u := binary.BigEndian.Uint64(b)
@@ -42,6 +55,12 @@ func RTUInt16ToFloat64(b []byte) float64 {
 // RTUInt32ToFloat64 converts 32 bit signed integer readings
 func RTUInt32ToFloat64(b []byte) float64 {
 	u := int32(binary.BigEndian.Uint32(b))
+	return float64(u)
+}
+
+// RTUInt32ToFloat64Swapped converts 32 bit unsigned integer readings with swapped word order
+func RTUInt32ToFloat64Swapped(b []byte) float64 {
+	u := int32(BigEndianUint32Swapped(b))
 	return float64(u)
 }
 

--- a/meters/rs485/transform_test.go
+++ b/meters/rs485/transform_test.go
@@ -1,0 +1,11 @@
+package rs485
+
+import "testing"
+
+func TestBigEndianUint32Swapped(t *testing.T) {
+	expect := uint32(0x03040102)
+	out := uint32(BigEndianUint32Swapped([]byte{1, 2, 3, 4}))
+	if out != expect {
+		t.Errorf("wanted: %08x, got %08x", expect, out)
+	}
+}


### PR DESCRIPTION
This PR adds swapped 32bit readings for the `read` command. This is e.g. necessary to access the E3/DC battery storage simple mode, see https://github.com/andig/evcc/issues/82