### PR TITLE
Adding ORNO WE-514, WE-515, WE-516 and WE-517 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ manuals for definitive guidance):
 | ABB A/B-Series | 3 | + | + | + | + | + | + | + | + |
 | BE MPM3MP | 3 | + | + | + | + | + | + | - | - |
 | KOSTAL Smart Energy Meter | 3 | + | + | + | + | + | + | + | - |
+| ORNO WE-514/515 | 1 | + | + | + | + | + | - | - | - |
+| ORNO WE-516/517 | 3 | + | + | + | + | + | + | + | - |
 
 - **SDM120**: Cheap and small (1TE), but communication parameters can only be set over MODBUS, which is currently not supported by this project.
 You can use e.g. [SDM120C](https://github.com/gianfrdp/SDM120C) to change parameters.
@@ -272,6 +274,12 @@ this as the meter ID.
 It has two tariffs, both import and export depending on meter version and compact (4TE). It's often used with Viessmann heat pumps.
 - **BE MPM3PM**: Compact (4TE) three phase meter.
 - **KOSTAL Smart Energy Meter**: Slave device for Kostal grid inverters. Known [bug](https://github.com/volkszaehler/mbmd/pull/61#issuecomment-570081618) in inverter firmware with Total Export Energy.
+- **ORNO WE-514/515**: Low cost single phase meter 
+By default, the meter communicates using 9600 8E1. The meter ID is 1. Meter ID, bus speed and other parameters are configurable via  [Software(Windows only)](https://www.partner.orno.pl/grafiki2/PC%20softwre170621.rar)
+WE-515 has a lithium battery and multi-tariff support, WE-514 does not support tariff zones.
+- **ORNO WE-516/517**: Low cost three phase meter.
+By default, the meter communicates using 9600 8E1. The meter ID is 1. Meter ID, bus speed and other parameters are configurable via  [Software(Windows only)](https://www.partner.orno.pl/grafiki2/PC%20softwre170621.rar)
+WE-517 has a lithium battery and multi-tariff support, WE-516 does not support tariff zones.
 
 ## Modbus TCP Grid Inverters
 

--- a/docs/mbmd_inspect.md
+++ b/docs/mbmd_inspect.md
@@ -24,6 +24,8 @@ mbmd inspect [flags]
                               INEPRO   Inepro Metering Pro 380
                               JANITZA  Janitza B-Series meters
                               MPM      Bernecker Engineering MPM3PM meters
+                              ORNO1P   ORNO WE-514 & WE-515
+                              ORNO3P   ORNO WE-516 & WE-517
                               SBC      Saia Burgess Controls ALE3 meters
                               SDM      Eastron SDM630
                               SDM220   Eastron SDM220

--- a/docs/mbmd_run.md
+++ b/docs/mbmd_run.md
@@ -23,6 +23,8 @@ mbmd run [flags]
                                         INEPRO   Inepro Metering Pro 380
                                         JANITZA  Janitza B-Series meters
                                         MPM      Bernecker Engineering MPM3PM meters
+                                        ORNO1P   ORNO WE-514 & WE-515
+                                        ORNO3P   ORNO WE-516 & WE-517
                                         SBC      Saia Burgess Controls ALE3 meters
                                         SDM      Eastron SDM630
                                         SDM220   Eastron SDM220

--- a/meters/rs485/orno1p.go
+++ b/meters/rs485/orno1p.go
@@ -1,0 +1,154 @@
+package rs485
+
+import . "github.com/volkszaehler/mbmd/meters"
+
+func init() {
+	Register(NewORNO1PProducer)
+}
+
+const (
+	METERTYPE_ORNO1p = "ORNO1p"
+)
+
+/*
+ * Opcodes for ORNO WE-514 and WE-515
+ * https://github.com/gituser-rk/orno-modbus-mqtt/blob/master/Register%20description%20OR-WE-514%26OR-WE-515.pdf
+*/
+
+var ops1p Opcodes = Opcodes{
+
+		Frequency:       0x130, // 16 bit, 0.01Hz
+
+		VoltageL1:       0x131, // 16 bit, 0.01V
+		CurrentL1:       0x139, // 16 bit, 0.001A
+		PowerL1:         0x140, // 32 bit, 0.001kW
+		ReactivePowerL1: 0x148, // 32 bit, 0.001kvar
+		ApparentPowerL1: 0x150, // 32 bit, 0.001kva
+		CosphiL1:        0x158, // 16 bit, 0,001 
+
+		VoltageL2:       0x132, // 16 bit, 0.01V
+		CurrentL2:       0x13B, // 32 bit, 0.001A
+		PowerL2:         0x142, // 32 bit, 0.001kW
+		ReactivePowerL2: 0x14A, // 32 bit, 0.001kvar
+		ApparentPowerL2: 0x152, // 32 bit, 0.001kva
+		CosphiL2:        0x159, // 16 bit, 0,001
+
+		VoltageL3:       0x133, // 16 bit, 0.01V
+		CurrentL3:       0x13D, // 32 bit, 0.001A
+		PowerL3:         0x144, // 32 bit, 0.001kW
+		ReactivePowerL3: 0x14C, // 32 bit, 0.001kvar
+		ApparentPowerL3: 0x154, // 32 bit, 0.001kva
+		CosphiL3:        0x15A, // 16 bit, 0,001
+
+		Power:           0x146, // 32 bit, 0.001kW
+		ReactivePower:   0x14E, // 32 bit, 0.001kvar
+		ApparentPower:   0x156, // 32 bit, 0.001kva
+		Cosphi:          0x15B, // 16 bit, 0.001
+
+		Sum:             0xA000, //32 Bit, 0.01kwh
+		SumT1:           0xA002, //32 Bit, 0.01kwh
+		SumT2:           0xA004, //32 Bit, 0.01kwh
+//		SumT3:           0xA006, //32 Bit, 0.01kwh // currently not supported
+//		SumT4:           0xA008, //32 Bit, 0.01kwh // currently not supported
+		ReactiveSum:     0xA01E, //32 Bit, 0.01kvarh
+		ReactiveSumT1:   0xA020, //32 Bit, 0.01kvarh
+		ReactiveSumT2:   0xA022, //32 Bit, 0.01kvarh
+//		ReactiveSumT3:   0xA024, //32 Bit, 0.01kvarh // currently not supported
+//		ReactiveSumT4:   0xA026, //32 Bit, 0.01kvarh // currently not supported
+	}
+
+type ORNO1PProducer struct {
+	Opcodes
+}
+
+func NewORNO1PProducer() Producer {
+	return &ORNO1PProducer{Opcodes: ops1p}
+}
+
+// Type implements Producer interface
+func (p *ORNO1PProducer) Type() string {
+	return METERTYPE_ORNO1p
+}
+
+// Description implements Producer interface
+func (p *ORNO1PProducer) Description() string {
+	return "ORNO WE-514 & WE-515"
+}
+
+// snip creates modbus operation
+func (p *ORNO1PProducer) snip(iec Measurement, readlen uint16) Operation {
+	return Operation{
+		FuncCode: ReadHoldingReg,
+		OpCode:   p.Opcode(iec), // adjust according to docs
+		ReadLen:  readlen,
+		IEC61850: iec,
+	}
+}
+
+// snip16 creates modbus operation for single register
+func (p *ORNO1PProducer) snip16(iec Measurement, scaler ...float64) Operation {
+	snip := p.snip(iec, 1)
+
+	snip.Transform = RTUUint16ToFloat64 // default conversion
+	if len(scaler) > 0 {
+		snip.Transform = MakeScaledTransform(snip.Transform, scaler[0])
+	}
+
+	return snip
+}
+
+// snip32 creates modbus operation for double register
+func (p *ORNO1PProducer) snip32(iec Measurement, scaler ...float64) Operation {
+	snip := p.snip(iec, 2)
+
+	snip.Transform = RTUUint32ToFloat64 // default conversion
+	if len(scaler) > 0 {
+		snip.Transform = MakeScaledTransform(snip.Transform, scaler[0])
+	}
+
+	return snip
+}
+
+func (p *ORNO1PProducer) Probe() Operation {
+	return p.snip16(VoltageL1,100)
+}
+
+// Produce implements Producer interface
+func (p *ORNO1PProducer) Produce() (res []Operation) {
+
+
+	for _, op := range []Measurement{
+		VoltageL1,
+		Frequency,
+	} {
+		res = append(res, p.snip16(op,100))
+	}
+
+	for _, op := range []Measurement{
+		CurrentL1,
+	} {
+		res = append(res, p.snip32(op, 1000))
+	}
+
+	for _, op := range []Measurement{
+		PowerL1, ReactivePowerL1, ApparentPowerL1,
+	} {
+		res = append(res, p.snip32(op, 1))
+	}
+
+	for _, op := range []Measurement{
+		CosphiL1,
+	} {
+		res = append(res, p.snip16(op, 1000))
+	}
+
+	for _, op := range []Measurement{
+		Sum,ReactiveSum,
+	} {
+		res = append(res, p.snip32(op, 100))
+	}
+	return res
+}
+
+
+

--- a/meters/rs485/orno3p.go
+++ b/meters/rs485/orno3p.go
@@ -1,0 +1,186 @@
+package rs485
+
+import . "github.com/volkszaehler/mbmd/meters"
+
+func init() {
+	Register(NewORNO3PProducer)
+    
+}
+
+const (
+	METERTYPE_ORNO3p = "ORNO3p"
+)
+
+var ops3p Opcodes = Opcodes{
+
+		Frequency:       0x0014, // 32 bit, Hz
+
+		VoltageL1:       0x000E, // 32 bit, V
+		CurrentL1:       0x0016, // 32 bit, A
+		PowerL1:         0x001E, // 32 bit, kW
+		ReactivePowerL1: 0x0026, // 32 bit, kvar
+		ApparentPowerL1: 0x002E, // 32 bit, kva
+		CosphiL1:        0x0036, // 32 bit, XX,X(literal)
+
+		VoltageL2:       0x0010, // 32 bit, V
+		CurrentL2:       0x0018, // 32 bit, A
+		PowerL2:         0x0020, // 32 bit, kW
+		ReactivePowerL2: 0x0028, // 32 bit, kvar
+		ApparentPowerL2: 0x0030, // 32 bit, kva
+		CosphiL2:        0x0038, // 32 bit, XX,X(literal)
+
+		VoltageL3:       0x0012, // 32 bit, V
+		CurrentL3:       0x001A, // 32 bit, A
+		PowerL3:         0x0022, // 32 bit, kW
+		ReactivePowerL3: 0x002A, // 32 bit, kvar
+		ApparentPowerL3: 0x0032, // 32 bit, kva
+		CosphiL3:        0x003A, // 32 bit, XX,X(literal)
+
+
+		Power:           0x001C, // 32 bit, kW
+		ReactivePower:   0x0024, // 32 bit, kvar
+		ApparentPower:   0x002C, // 32 bit, kva
+		Cosphi:          0x0034, // 32 bit, XX,X(literal)
+
+		Sum:             0x0100, //32 Bit, kwh
+		SumL1:           0x0102, //32 Bit, kwh
+		SumL2:           0x0104, //32 Bit, kwh
+		SumL3:           0x0106, //32 Bit, kwh
+
+		Import:          0x0108, //32 Bit, kwh
+		ImportL1:        0x010A, //32 Bit, kwh
+		ImportL2:        0x010C, //32 Bit, kwh
+		ImportL3:        0x010E, //32 Bit, kwh
+
+		Export:          0x0110, //32 Bit, kwh
+		ExportL1:        0x0112, //32 Bit, kwh
+		ExportL2:        0x0114, //32 Bit, kwh
+		ExportL3:        0x0116, //32 Bit, kwh
+
+		ReactiveSum:     0x0118, //32 Bit, kvarh
+		ReactiveSumL1:   0x011A, //32 Bit, kvarh
+		ReactiveSumL2:   0x011C, //32 Bit, kvarh
+		ReactiveSumL3:   0x011E, //32 Bit, kvarh
+
+		ReactiveImport:  0x0120, //32 Bit, kvarh
+		ReactiveImportL1:0x0122, //32 Bit, kvarh
+		ReactiveImportL2:0x0124, //32 Bit, kvarh
+		ReactiveImportL3:0x0126, //32 Bit, kvarh
+
+		ReactiveExport:  0x0128, //32 Bit, kvarh
+		ReactiveExportL1:0x012A, //32 Bit, kvarh
+		ReactiveExportL2:0x012C, //32 Bit, kvarh
+		ReactiveExportL3:0x012E, //32 Bit, kvarh
+
+		SumT1:           0x0130, //32 Bit, kwh
+		ImportT1:        0x0132, //32 Bit, kwh
+		ExportT1:        0x0134, //32 Bit, kwh
+		ReactiveSumT1:   0x0136, //32 Bit, kvarh
+		ReactiveImportT1:0x0138, //32 Bit, kvarh
+		ReactiveExportT1:0x013A, //32 Bit, kvarh
+
+		SumT2:           0x013C, //32 Bit, kwh
+		ImportT2:        0x013E, //32 Bit, kwh
+		ExportT2:        0x0140, //32 Bit, kwh
+		ReactiveSumT2:   0x0142, //32 Bit, kvarh
+		ReactiveImportT2:0x0144, //32 Bit, kvarh
+		ReactiveExportT2:0x0146, //32 Bit, kvarh
+
+/* // Curently not supported
+		SumT3:           0x0148, //32 Bit, kwh
+		ImportT3:        0x014A, //32 Bit, kwh
+		ExportT3:        0x014C, //32 Bit, kwh
+		ReactiveSumT3:   0x015E, //32 Bit, kvarh
+		ReactiveImportT3:0x0150, //32 Bit, kvarh
+		ReactiveExportT3:0x0152, //32 Bit, kvarh
+
+		SumT4:           0x0154, //32 Bit, kwh
+		ImportT4:        0x0156, //32 Bit, kwh
+		ExportT4:        0x0158, //32 Bit, kwh
+		ReactiveSumT4:   0x015A, //32 Bit, kvarh
+		ReactiveImportT4:0x015C, //32 Bit, kvarh
+		ReactiveExportT4:0x015E, //32 Bit, kvarh
+*/
+	}
+    
+
+
+type ORNO3PProducer struct {
+	Opcodes
+}
+
+func NewORNO3PProducer() Producer {
+	return &ORNO3PProducer{Opcodes: ops3p}
+}
+
+// Type implements Producer interface
+func (p *ORNO3PProducer) Type() string {
+	return METERTYPE_ORNO3p
+}
+
+// Description implements Producer interface
+func (p *ORNO3PProducer) Description() string {
+	return "ORNO WE-516 & WE-517"
+}
+
+// snip creates modbus operation
+func (p *ORNO3PProducer) snip(iec Measurement, readlen uint16) Operation {
+        return Operation{
+                FuncCode: ReadHoldingReg,
+                OpCode:   p.Opcode(iec), // adjust according to docs
+                ReadLen:  readlen,
+                IEC61850: iec,
+        }
+}
+
+// snip32 creates modbus operation for double register
+func (p *ORNO3PProducer) snip32(iec Measurement, scaler ...float64) Operation {
+        snip := p.snip(iec, 2)
+
+        snip.Transform = RTUIeee754ToFloat64 // default conversion
+        if len(scaler) > 0 {
+                snip.Transform = MakeScaledTransform(snip.Transform, scaler[0])
+        }
+
+        return snip
+}
+
+func (p *ORNO3PProducer) Probe() Operation {
+        return p.snip32(VoltageL1,1)
+}
+
+// Produce implements Producer interface
+func (p *ORNO3PProducer) Produce() (res []Operation) {
+
+// These values are stored as literals
+	for _, op := range []Measurement{
+		Frequency,
+		VoltageL1, CurrentL1, CosphiL1,
+		VoltageL2, CurrentL2, CosphiL2,
+		VoltageL3, CurrentL3, CosphiL3,
+		Cosphi,
+		Sum, SumL1, SumL2, SumL3,
+		Import, ImportL1, ImportL2, ImportL3,
+		Export, ExportL1, ExportL2, ExportL3,
+		ReactiveSum, ReactiveSumL1, ReactiveSumL2, ReactiveSumL3,
+		ReactiveImport, ReactiveImportL1, ReactiveImportL2, ReactiveImportL3,
+		ReactiveExport, ReactiveExportL1, ReactiveExportL2, ReactiveExportL3,
+		SumT1, ImportT1, ExportT1, ReactiveSumT1, ReactiveImportT1, ReactiveExportT1,
+		SumT2, ImportT2, ExportT2, ReactiveSumT2, ReactiveImportT2, ReactiveExportT2,
+	} {
+		res = append(res, p.snip32(op, 1))
+	}
+
+
+// For Power values, we need to scale by 1000 (aka convert kW/kva -> W/va)
+	for _, op := range []Measurement{
+		PowerL1, ReactivePowerL1, ApparentPowerL1,
+		PowerL2, ReactivePowerL2, ApparentPowerL2,
+		PowerL3, ReactivePowerL3, ApparentPowerL3,
+		Power, ReactivePower, ApparentPower,
+	} {
+		res = append(res, p.snip32(op, 0.001))
+	}
+	return res
+}
+


### PR DESCRIPTION
Hi, 

this should implement #127 and also add the single phase variants WE-514/515.

I tested the code on WE-514/515, OpCodes for WE-516/517 were added based on data from #127 and the original Windows Software. Unfortunately i do not have a We-516/517, so scaling factors might be incorrect. 

Now i'm a total go n00b, so please be patient with me. 