### PR TITLE
fix sunspec query

### DIFF
--- a/meters/sunspec/sunspec.go
+++ b/meters/sunspec/sunspec.go
@@ -302,7 +302,16 @@ func (d *SunSpec) Query(client modbus.Client) (res []meters.MeasurementResult, e
 			// sort blocks so block 0 is always read first
 			sortedBlocks := make([]int, len(blockMap))
 			for k := range blockMap {
-				sortedBlocks = append(sortedBlocks, k)
+				// check if value already exists in array
+				contains := false
+				for _, l := range sortedBlocks {
+					if l == k {
+						contains = true
+					}
+				}
+				if !contains {
+					sortedBlocks = append(sortedBlocks, k)
+				}
 			}
 			sort.Ints(sortedBlocks)
 


### PR DESCRIPTION
Der ursprüngliche Stand hat bei mir dazu geführt, dass das Programm mit dem Fehler `panic: no such block` abgestürzt ist. 

Soweit ich den Code verstanden habe ist der Grund, dass die Variable zwei Einträge mit 0 hat und dadurch zwei Mal `block := model.MustBlock(blockID)` ausgeführt wird, obwohl nur ein Block vorhanden ist. 