### PR TITLE
update go version and improve documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM golang:1.13-alpine as builder
+FROM golang:1.15-alpine as builder
 
 # Install git + SSL ca certificates.
 # Git is required for fetching the dependencies.

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Both device APIs can also be called without the device id to return data for all
 
 The `/api/status` endpoint provides the following information:
 
-    $ curl http://localhost:8080/status
+    $ curl http://localhost:8080/api/status
     {
       "StartTime": "2017-01-25T16:35:50.839829945+01:00",
       "UpTime": 65587.177092186,

--- a/docs/mbmd_run.md
+++ b/docs/mbmd_run.md
@@ -39,7 +39,7 @@ mbmd run [flags]
                                        Example: -d SDM:1@/dev/USB11 -d SMA:126@localhost:502
       --influx-database string       InfluxDB database
       --influx-measurement string    InfluxDB measurement (default "data")
-      --influx-organization string   InfluxDB organization
+      --influx-organization string   InfluxDB organization (use an empty string ("") for InfluxDB 1.8)
       --influx-password string       InfluxDB password (optional)
       --influx-token string          InfluxDB token (optional)
   -i, --influx-url string            InfluxDB URL. ex: http://10.10.1.1:8086


### PR DESCRIPTION
Folgende Änderungsvorschläge:  
- Kleiner Fehler in der README.md behoben  
- Kommentar für die Verwendung von InfluxDB 1.8 in docs/mbmd_run.md zum besseren Verständnis
- go-Version im Dockerfile auf die aktuelle Version aktualisiert. Im .travis.yml ist die Version ebenfalls noch auf 1.13 