### PR TITLE
fix: golang version for builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM golang:1.13-alpine as builder
+FROM golang:1.16-alpine as builder
 
 # Install git + SSL ca certificates.
 # Git is required for fetching the dependencies.


### PR DESCRIPTION
The `embed` package requires at least golang 1.16 to be supported.
