### PR TITLE
Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ start `mbmd` as service (put this into ``/etc/systemd/system``):
     [Install]
     WantedBy=multi-user.target
 
-You might need to adjust the ``-s`` parameter depending on where your
+You might need to adjust the ``-a`` parameter depending on where your
 RS485 adapter is connected. Then, use
 
     systemctl start mbmd


### PR DESCRIPTION
The pararmeter for the adapter is -a not -s
I guess that's a typo, s is next to a on qwertz...