### PR TITLE
fixed: delay for setting new slave-ID never triggered

### DIFF
--- a/meters/rtu.go
+++ b/meters/rtu.go
@@ -72,9 +72,9 @@ func (b *RTU) Slave(deviceID uint8) {
 	// Some devices like SDM need to have a little pause between querying different device ids
 	if b.prevID != 0 && deviceID != b.prevID {
 		time.Sleep(time.Duration(100) * time.Millisecond)
-		b.prevID = deviceID
 	}
 
+	b.prevID = deviceID
 	b.Handler.SetSlave(deviceID)
 }
 

--- a/meters/rtuovertcp.go
+++ b/meters/rtuovertcp.go
@@ -60,9 +60,9 @@ func (b *RTUOverTCP) Slave(deviceID uint8) {
 	// Some devices like SDM need to have a little pause between querying different device ids
 	if b.prevID != 0 && deviceID != b.prevID {
 		time.Sleep(time.Duration(100) * time.Millisecond)
-		b.prevID = deviceID
 	}
 
+	b.prevID = deviceID
 	b.Handler.SetSlave(deviceID)
 }
 


### PR DESCRIPTION
for the first run b.prevID is always 0, so the "if" never matches and b.prevID never get an update.