### PR TITLE
Only set slave when needed

### DIFF
--- a/meters/rtu.go
+++ b/meters/rtu.go
@@ -47,6 +47,7 @@ func NewRTU(device string, baudrate int, comset string) Connection {
 		device:  device,
 		Client:  client,
 		Handler: handler,
+		prevID: 0,
 	}
 
 	return b
@@ -70,12 +71,11 @@ func (b *RTU) Logger(l Logger) {
 // Slave sets the modbus device id for the following operations
 func (b *RTU) Slave(deviceID uint8) {
 	// Some devices like SDM need to have a little pause between querying different device ids
-	if b.prevID != 0 && deviceID != b.prevID {
-		time.Sleep(time.Duration(100) * time.Millisecond)
+	if b.prevID == 0 || deviceID != b.prevID {
+		b.prevID = deviceID
+		b.Handler.SetSlave(deviceID)
+		time.Sleep(time.Duration(200) * time.Millisecond)
 	}
-
-	b.prevID = deviceID
-	b.Handler.SetSlave(deviceID)
 }
 
 // Timeout sets the modbus timeout

--- a/meters/rtu.go
+++ b/meters/rtu.go
@@ -47,7 +47,6 @@ func NewRTU(device string, baudrate int, comset string) Connection {
 		device:  device,
 		Client:  client,
 		Handler: handler,
-		prevID: 0,
 	}
 
 	return b

--- a/meters/rtu.go
+++ b/meters/rtu.go
@@ -73,7 +73,7 @@ func (b *RTU) Slave(deviceID uint8) {
 	if b.prevID == 0 || deviceID != b.prevID {
 		b.prevID = deviceID
 		b.Handler.SetSlave(deviceID)
-		time.Sleep(time.Duration(200) * time.Millisecond)
+		time.Sleep(200 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
This PR fixes the timeouts with the ORNO WE-517 meter as reported in #155
It only calls SetSlave() when the deviceID changes.