### PR TITLE
Increase timeout to 600 ms

### DIFF
--- a/meters/rtu.go
+++ b/meters/rtu.go
@@ -33,7 +33,7 @@ func NewClientHandler(device string, baudrate int, comset string) *modbus.RTUCli
 		log.Fatalf("Invalid communication set specified: %s. See -h for help.", comset)
 	}
 
-	handler.Timeout = 300 * time.Millisecond
+	handler.Timeout = 600 * time.Millisecond
 
 	return handler
 }


### PR DESCRIPTION
When idle the ORNO OR-WE-517 meter works fine and `mbmd` can read it without any problems. However when I charge my car (the meter is in front of my EV charger) timeout start to occur. When I increase the default timeout of 300 ms to 600 ms the timeout disappear. 
```
Apr 30 01:34:49 framboos mbmd[1929]: 2022/04/30 01:34:49 device ORNO3P1.1 did not respond (1/3): read failed: serial: timeout
Apr 30 01:34:50 framboos mbmd[1929]: 2022/04/30 01:34:50 device ORNO3P1.1 did not respond (2/3): read failed: serial: timeout
Apr 30 01:34:55 framboos mbmd[1929]: 2022/04/30 01:34:55 device ORNO3P1.1 did not respond (3/3): read failed: serial: timeout
Apr 30 01:34:56 framboos mbmd[1929]: 2022/04/30 01:34:56 device ORNO3P1.1 is offline
Apr 30 01:34:57 framboos mbmd[1929]: 2022/04/30 01:34:57 device ORNO3P1.1 is offline - reactivating
Apr 30 01:35:02 framboos mbmd[1929]: 2022/04/30 01:35:02 device ORNO3P1.1 did not respond (1/3): read failed: serial: timeout
Apr 30 01:35:03 framboos mbmd[1929]: 2022/04/30 01:35:03 device ORNO3P1.1 did not respond (2/3): read failed: serial: timeout
Apr 30 01:35:08 framboos mbmd[1929]: 2022/04/30 01:35:08 device ORNO3P1.1 did not respond (3/3): read failed: serial: timeout
Apr 30 01:35:09 framboos mbmd[1929]: 2022/04/30 01:35:09 device ORNO3P1.1 is offline
Apr 30 01:35:10 framboos mbmd[1929]: 2022/04/30 01:35:10 device ORNO3P1.1 is offline - reactivating
Apr 30 01:35:15 framboos mbmd[1929]: 2022/04/30 01:35:15 device ORNO3P1.1 did not respond (1/3): read failed: serial: timeout
Apr 30 01:35:16 framboos mbmd[1929]: 2022/04/30 01:35:16 device ORNO3P1.1 did not respond (2/3): read failed: serial: timeout
Apr 30 01:35:21 framboos mbmd[1929]: 2022/04/30 01:35:21 device ORNO3P1.1 did not respond (3/3): read failed: serial: timeout
Apr 30 01:35:22 framboos mbmd[1929]: 2022/04/30 01:35:22 device ORNO3P1.1 is offline
Apr 30 01:35:23 framboos mbmd[1929]: 2022/04/30 01:35:23 device ORNO3P1.1 is offline - reactivating
```