### PR TITLE
Add encoding package and clarify encoding function naming

### DIFF
--- a/cmd/read.go
+++ b/cmd/read.go
@@ -146,8 +146,8 @@ func decode(b []byte, length int, enc string) string {
 		if length != 2 {
 			log.Fatal("Invalid length for int32(swapped) encoding")
 		}
-		u := encoding.BigEndianUint32Swapped(b)
-		return strconv.FormatInt(int64(int32(u)), 10)
+		u := encoding.Int32LswFirst(b)
+		return strconv.FormatInt(int64(u), 10)
 	case "uint":
 		u := bytes2uint(b, length)
 		return strconv.FormatUint(u, 10)
@@ -155,14 +155,14 @@ func decode(b []byte, length int, enc string) string {
 		if length != 2 {
 			log.Fatal("Invalid length for uint32(swapped) encoding")
 		}
-		u := encoding.BigEndianUint32Swapped(b)
-		return strconv.FormatUint(uint64(uint32(u)), 10)
+		u := encoding.Uint32LswFirst(b)
+		return strconv.FormatUint(uint64(u), 10)
 	case "hex":
 		return fmt.Sprintf("%02x", b)
 	case "string":
 		return string(b)
 	case "stringswapped", "strings":
-		return encoding.StringSwapped(b)
+		return encoding.StringLsbFirst(b)
 	case "float":
 		f := bytes2float(b, length)
 		return fmt.Sprintf("%f", f)

--- a/encoding/int.go
+++ b/encoding/int.go
@@ -1,8 +1,0 @@
-package encoding
-
-// BigEndianUint32Swapped converts bytes to uint32 wrapped as uint64 with swapped word order.
-// To use the result as int32 value make sure to convert to uint32 first before converting to int32.
-func BigEndianUint32Swapped(b []byte) uint32 {
-	_ = b[3] // bounds check hint to compiler; see golang.org/issue/14808
-	return uint32(b[3])<<16 | uint32(b[2])<<24 | uint32(b[1]) | uint32(b[0])<<8
-}

--- a/encoding/number.go
+++ b/encoding/number.go
@@ -1,0 +1,63 @@
+package encoding
+
+import (
+	"encoding/binary"
+	"math"
+)
+
+// Uint16 decodes bytes as uint16 in network byte order (big endian)
+func Uint16(b []byte) uint16 {
+	return binary.BigEndian.Uint16(b)
+}
+
+// Int16 decodes bytes as int16 in network byte order (big endian)
+func Int16(b []byte) int16 {
+	return int16(binary.BigEndian.Uint16(b))
+}
+
+// Uint32 decodes bytes as uint32 in network byte order (big endian)
+func Uint32(b []byte) uint32 {
+	return binary.BigEndian.Uint32(b)
+}
+
+// Int32 decodes bytes as int32 in network byte order (big endian)
+func Int32(b []byte) int32 {
+	return int32(binary.BigEndian.Uint32(b))
+}
+
+// Uint64 decodes bytes as uint64 in network byte order (big endian)
+func Uint64(b []byte) uint64 {
+	return binary.BigEndian.Uint64(b)
+}
+
+// Int64 decodes bytes as int64 in network byte order (big endian)
+func Int64(b []byte) int64 {
+	return int64(binary.BigEndian.Uint64(b))
+}
+
+// Float32 decodes bytes as float32 in network byte order (big endian)
+func Float32(b []byte) float32 {
+	return math.Float32frombits(Uint32(b))
+}
+
+// Float64 decodes bytes as float64 in network byte order (big endian)
+func Float64(b []byte) float64 {
+	return math.Float64frombits(Uint64(b))
+}
+
+// Uint32LswFirst decodes bytes as uint32 in network byte order (big endian) with least significant word first
+func Uint32LswFirst(b []byte) uint32 {
+	_ = b[3] // bounds check hint to compiler; see golang.org/issue/14808
+	return uint32(b[2])<<24 | uint32(b[3])<<16 | uint32(b[0])<<8 | uint32(b[1])
+}
+
+// Int32LswFirst decodes bytes as int32 in network byte order (big endian) with least significant word first
+func Int32LswFirst(b []byte) int32 {
+	_ = b[3] // bounds check hint to compiler; see golang.org/issue/14808
+	return int32(uint32(b[2])<<24 | uint32(b[3])<<16 | uint32(b[0])<<8 | uint32(b[1]))
+}
+
+// Float32LswFirst decodes bytes as float32 in network byte order (big endian) with least significant word first
+func Float32LswFirst(b []byte) float32 {
+	return math.Float32frombits(Uint32LswFirst(b))
+}

--- a/encoding/number_test.go
+++ b/encoding/number_test.go
@@ -2,9 +2,9 @@ package encoding
 
 import "testing"
 
-func TestBigEndianUint32Swapped(t *testing.T) {
+func TestUint32LswFirst(t *testing.T) {
 	expect := uint32(0x03040102)
-	out := uint32(BigEndianUint32Swapped([]byte{1, 2, 3, 4}))
+	out := uint32(Uint32LswFirst([]byte{1, 2, 3, 4}))
 	if out != expect {
 		t.Errorf("wanted: %08x, got %08x", expect, out)
 	}

--- a/encoding/string.go
+++ b/encoding/string.go
@@ -1,14 +1,12 @@
 package encoding
 
-// StringSwapped does not modify the underlying byte slice
-func StringSwapped(s []byte) string {
+// StringLsbFirst decodes bytes as string with words in little endian encoding
+func StringLsbFirst(s []byte) string {
 	b := make([]byte, len(s))
 	_ = copy(b, s)
 
 	for i := 0; i < len(b); i += 2 {
-		c := b[i]
-		b[i] = b[i+1]
-		b[i+1] = c
+		b[i], b[i+1] = b[i+1], b[i]
 	}
 
 	return string(b)

--- a/encoding/string_test.go
+++ b/encoding/string_test.go
@@ -1,0 +1,11 @@
+package encoding
+
+import "testing"
+
+func TestStringLswFirst(t *testing.T) {
+	expect := "ABCD"
+	out := StringLsbFirst([]byte("BADC"))
+	if out != expect {
+		t.Errorf("wanted: %s, got %s", expect, out)
+	}
+}

--- a/meters/rs485/transform.go
+++ b/meters/rs485/transform.go
@@ -1,9 +1,6 @@
 package rs485
 
 import (
-	"encoding/binary"
-	"math"
-
 	"github.com/volkszaehler/mbmd/encoding"
 )
 
@@ -12,70 +9,57 @@ type RTUTransform func([]byte) float64
 
 // RTUIeee754ToFloat64 converts 32 bit IEEE 754 float readings
 func RTUIeee754ToFloat64(b []byte) float64 {
-	bits := binary.BigEndian.Uint32(b)
-	f := math.Float32frombits(bits)
-	return float64(f)
+	return float64(encoding.Float32(b))
 }
 
 // RTUIeee754ToFloat64Swapped converts 32 bit IEEE 754 float readings
 func RTUIeee754ToFloat64Swapped(b []byte) float64 {
-	bits := encoding.BigEndianUint32Swapped(b)
-	f := math.Float32frombits(bits)
-	return float64(f)
+	return float64(encoding.Float32LswFirst(b))
 }
 
 // RTUFloat64ToFloat64 converts 64 bit float readings
 func RTUFloat64ToFloat64(b []byte) float64 {
-	bits := binary.BigEndian.Uint64(b)
-	return math.Float64frombits(bits)
+	return encoding.Float64(b)
 }
 
 // RTUUint16ToFloat64 converts 16 bit unsigned integer readings
 func RTUUint16ToFloat64(b []byte) float64 {
-	u := binary.BigEndian.Uint16(b)
-	return float64(u)
+	return float64(encoding.Uint16(b))
 }
 
 // RTUUint32ToFloat64 converts 32 bit unsigned integer readings
 func RTUUint32ToFloat64(b []byte) float64 {
-	u := binary.BigEndian.Uint32(b)
-	return float64(u)
+	return float64(encoding.Uint32(b))
 }
 
 // RTUUint32ToFloat64Swapped converts 32 bit unsigned integer readings with swapped word order
 func RTUUint32ToFloat64Swapped(b []byte) float64 {
-	u := uint32(encoding.BigEndianUint32Swapped(b))
-	return float64(u)
+	return float64(encoding.Uint32LswFirst(b))
 }
 
 // RTUUint64ToFloat64 converts 64 bit unsigned integer readings
 func RTUUint64ToFloat64(b []byte) float64 {
-	u := binary.BigEndian.Uint64(b)
-	return float64(u)
+	return float64(encoding.Uint64(b))
 }
 
 // RTUInt16ToFloat64 converts 16 bit signed integer readings
 func RTUInt16ToFloat64(b []byte) float64 {
-	u := int16(binary.BigEndian.Uint16(b))
-	return float64(u)
+	return float64(encoding.Int16(b))
 }
 
 // RTUInt32ToFloat64 converts 32 bit signed integer readings
 func RTUInt32ToFloat64(b []byte) float64 {
-	u := int32(binary.BigEndian.Uint32(b))
-	return float64(u)
+	return float64(encoding.Int32(b))
 }
 
 // RTUInt32ToFloat64Swapped converts 32 bit unsigned integer readings with swapped word order
 func RTUInt32ToFloat64Swapped(b []byte) float64 {
-	u := int32(encoding.BigEndianUint32Swapped(b))
-	return float64(u)
+	return float64(encoding.Int32LswFirst(b))
 }
 
 // RTUInt64ToFloat64 converts 64 bit signed integer readings
 func RTUInt64ToFloat64(b []byte) float64 {
-	u := int64(binary.BigEndian.Uint64(b))
-	return float64(u)
+	return float64(encoding.Int64(b))
 }
 
 // MakeScaledTransform creates an RTUTransform with applied scaler


### PR DESCRIPTION
Breaking change: `encoding.StringSwapped` becomes `encoding.StringLsbFirst`.