### PR TITLE
Add parameter to define timeout for Modbus RTU operations

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -143,7 +143,7 @@ func inspect(cmd *cobra.Command, args []string) {
 	defaultDevice := viper.GetString("adapter")
 	if defaultDevice != "" {
 		confHandler.DefaultDevice = defaultDevice
-		confHandler.ConnectionManager(defaultDevice, viper.GetBool("rtu"), viper.GetInt("baudrate"), viper.GetString("comset"))
+		confHandler.ConnectionManager(defaultDevice, viper.GetBool("rtu"), viper.GetInt("baudrate"), viper.GetString("comset"), viper.GetInt("timeout"))
 	}
 
 	// create devices from command line

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -56,7 +56,7 @@ func modbusClient() (meters.Connection, modbus.Client) {
 	}
 
 	// connection
-	conn := createConnection(adapter, viper.GetBool("rtu"), viper.GetInt("baudrate"), viper.GetString("comset"))
+	conn := createConnection(adapter, viper.GetBool("rtu"), viper.GetInt("baudrate"), viper.GetString("comset"), viper.GetInt("timeout"))
 	client := conn.ModbusClient()
 
 	// raw log

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,6 +54,11 @@ The default adapter can be overridden per device`,
 		`Communication parameters for default adapter, either 8N1 or 8E1.
 Only applicable if the default adapter is an RTU device`,
 	)
+	rootCmd.PersistentFlags().IntP(
+		"timeout", "t",
+		300,
+		`Timeout modbus RTU`,
+	)
 	rootCmd.PersistentFlags().Bool(
 		"rtu",
 		false,

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -206,7 +206,7 @@ func run(cmd *cobra.Command, args []string) {
 	defaultDevice := viper.GetString("adapter")
 	if defaultDevice != "" {
 		confHandler.DefaultDevice = defaultDevice
-		confHandler.ConnectionManager(defaultDevice, viper.GetBool("rtu"), viper.GetInt("baudrate"), viper.GetString("comset"))
+		confHandler.ConnectionManager(defaultDevice, viper.GetBool("rtu"), viper.GetInt("baudrate"), viper.GetString("comset"), viper.GetInt("timeout"))
 	}
 
 	// create devices from command line
@@ -233,7 +233,7 @@ func run(cmd *cobra.Command, args []string) {
 		if len(devices) == 0 {
 			// add adapters from configuration
 			for _, a := range conf.Adapters {
-				confHandler.ConnectionManager(a.Device, a.RTU, a.Baudrate, a.Comset)
+				confHandler.ConnectionManager(a.Device, a.RTU, a.Baudrate, a.Comset, viper.GetInt("timeout"))
 			}
 
 			// add devices from configuration

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -68,7 +68,7 @@ func scan(cmd *cobra.Command, args []string) {
 		log.Fatal("missing adapter configuration")
 	}
 
-	conn := createConnection(adapter, viper.GetBool("rtu"), viper.GetInt("baudrate"), viper.GetString("comset"))
+	conn := createConnection(adapter, viper.GetBool("rtu"), viper.GetInt("baudrate"), viper.GetString("comset"), viper.GetInt("timeout"))
 	client := conn.ModbusClient()
 
 	// raw log

--- a/meters/rtu.go
+++ b/meters/rtu.go
@@ -17,7 +17,7 @@ type RTU struct {
 }
 
 // NewClientHandler creates a serial line RTU modbus handler
-func NewClientHandler(device string, baudrate int, comset string) *modbus.RTUClientHandler {
+func NewClientHandler(device string, baudrate int, comset string, timeout int) *modbus.RTUClientHandler {
 	handler := modbus.NewRTUClientHandler(device)
 
 	handler.BaudRate = baudrate
@@ -33,14 +33,14 @@ func NewClientHandler(device string, baudrate int, comset string) *modbus.RTUCli
 		log.Fatalf("Invalid communication set specified: %s. See -h for help.", comset)
 	}
 
-	handler.Timeout = 300 * time.Millisecond
+	handler.Timeout = time.Duration(timeout) * time.Millisecond
 
 	return handler
 }
 
 // NewRTU creates a RTU modbus client
-func NewRTU(device string, baudrate int, comset string) Connection {
-	handler := NewClientHandler(device, baudrate, comset)
+func NewRTU(device string, baudrate int, comset string, timeout int) Connection {
+	handler := NewClientHandler(device, baudrate, comset, timeout)
 	client := modbus.NewClient(handler)
 
 	b := &RTU{


### PR DESCRIPTION
I run into the issue mentioned in pull request #258 with an ORNO 3 phase meter. 
These changes add a command line parameter  `-t timeout` to change to default timeout for Modbus RTU operations.