### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM golang:alpine as builder
+FROM golang:alpine AS builder
 
 # Install git + SSL ca certificates.
 # Git is required for fetching the dependencies.


### PR DESCRIPTION
Docker build meldet bei mir eine Warnung:

>  1 warning found (use docker --debug to expand):
>  - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 4)

Ist nur Kosmetik, aber wenn das "as" auch in Großbuchstaben ist, verschwindet die Warnung.