### PR TITLE
Add EM24_E1 as explicit meter to remove confusion with EM24

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ manuals for definitive guidance):
 
 | Meter | Phases | Voltage | Current | Power | Power Factor | Total Import | Total Export | Per-phase Import/Export | Line/Neutral THD |
 |---|---|---|---|---|---|---|---|---|---|
+| EM24 | 3 | + | + | + | + | + | + |  +/- | - |
+| EM24_E1 | 3 | + | + | + | + | + | + | +/- | - |
 | SDM54 | 3 | + | + | + | + | + | + | + | + |
 | SDM72 | 3 | - | - | + | - | + | + | - | - |
 | SDM120/220 | 1 | + | + | + | + | + | + | - | - |
@@ -259,6 +261,8 @@ manuals for definitive guidance):
 | B+G e-tech WS100 | 1 | + | + | + | - | + | + | - | - |
 | B+G e-tech DS100 | 3 | + | + | + | + | + | + | + | + |
 
+- **EM24-DIN**: Compact (4TE), 3P meter with RS-485 interface. Note: EM24 RS485 and Ethernet variant use different modbus registers.
+- **EM24-DIN_E1**: Compact (4TE), 3P meter with Ethernet interface. Note: EM24 RS485 and Ethernet variant use different modbus registers.
 - **SDM54**: Compact (3TE), 3P meter with a lot of features. Can be configured using the builtin display.
 - **SDM72**: Compact (4TE), 3P meter with bare minium of total measurements, no currents. Can be configured using the builtin display.
 - **SDM120**: Cheap and small (1TE), but communication parameters can only be set over MODBUS, which is currently not supported by this project.

--- a/README.md
+++ b/README.md
@@ -261,8 +261,8 @@ manuals for definitive guidance):
 | B+G e-tech WS100 | 1 | + | + | + | - | + | + | - | - |
 | B+G e-tech DS100 | 3 | + | + | + | + | + | + | + | + |
 
-- **EM24-DIN**: Compact (4TE), 3P meter with RS-485 interface. Note: EM24 RS485 and Ethernet variant use different modbus registers.
-- **EM24-DIN_E1**: Compact (4TE), 3P meter with Ethernet interface. Note: EM24 RS485 and Ethernet variant use different modbus registers.
+- **EM24**: Compact (4TE), 3P meter with RS-485 interface.
+- **EM24_E1**: Compact (4TE), 3P meter with Ethernet interface.
 - **SDM54**: Compact (3TE), 3P meter with a lot of features. Can be configured using the builtin display.
 - **SDM72**: Compact (4TE), 3P meter with bare minium of total measurements, no currents. Can be configured using the builtin display.
 - **SDM120**: Cheap and small (1TE), but communication parameters can only be set over MODBUS, which is currently not supported by this project.

--- a/docs/mbmd_inspect.md
+++ b/docs/mbmd_inspect.md
@@ -21,6 +21,7 @@ mbmd inspect [flags]
                             RTU
                               ABB       ABB A/B-Series meters
                               CGEM24    Carlo Gavazzi EM24
+                              CGEM24_E1 Carlo Gavazzi EM24_E1
                               CGEX3X0   Carlo Gavazzi EM/ET 330/340
                               DDM       DDM18SD
                               DMG610    Lovato DMG610

--- a/docs/mbmd_run.md
+++ b/docs/mbmd_run.md
@@ -16,6 +16,7 @@ mbmd run [flags]
                                        RTU
                                          ABB       ABB A/B-Series meters
                                          CGEM24    Carlo Gavazzi EM24
+                                         CGEM24_E1 Carlo Gavazzi EM24_E1
                                          CGEX3X0   Carlo Gavazzi EM/ET 330/340
                                          DDM       DDM18SD
                                          DMG610    Lovato DMG610

--- a/meters/rs485/carlogavazzi-em24.go
+++ b/meters/rs485/carlogavazzi-em24.go
@@ -14,7 +14,7 @@ type CarloGavazziEM24Producer struct {
 
 func NewCarloGavazziEM24Producer() Producer {
 	/***
-	 * Note: Carlo Gavazzi EM24 (RS-485 interface) and EM24_E1 (Ethernet interface)
+	 * Note: Carlo Gavazzi EM24 (RS-485)
 	 * have different register map.
 	 * Doc for EM24: https://www.ccontrols.com/support/dp/CarloGavazziEM24.pdf
 	 */

--- a/meters/rs485/carlogavazzi-em24.go
+++ b/meters/rs485/carlogavazzi-em24.go
@@ -15,7 +15,6 @@ type CarloGavazziEM24Producer struct {
 func NewCarloGavazziEM24Producer() Producer {
 	/***
 	 * Note: Carlo Gavazzi EM24 (RS-485)
-	 * have different register map.
 	 * Doc for EM24: https://www.ccontrols.com/support/dp/CarloGavazziEM24.pdf
 	 */
 	ops := Opcodes{

--- a/meters/rs485/carlogavazzi-em24_e1.go
+++ b/meters/rs485/carlogavazzi-em24_e1.go
@@ -14,7 +14,7 @@ type CarloGavazziEM24_E1Producer struct {
 
 func NewCarloGavazziEM24_E1Producer() Producer {
 	/***
-	 * Note: Carlo Gavazzi EM24 (RS-485 interface) and EM24_E1 (Ethernet interface)
+	 * Note: Carlo Gavazzi EM24_E1 (Ethernet)
 	 * have different register map.
 	 * Doc for EM24_E1: https://www.enika.eu/data/files/produkty/energy%20m/CP/em24%20ethernet%20cp.pdf
 	 */

--- a/meters/rs485/carlogavazzi-em24_e1.go
+++ b/meters/rs485/carlogavazzi-em24_e1.go
@@ -5,18 +5,18 @@ import (
 )
 
 func init() {
-	Register("CGEM24", NewCarloGavazziEM24Producer)
+	Register("CGEM24_E1", NewCarloGavazziEM24_E1Producer)
 }
 
-type CarloGavazziEM24Producer struct {
+type CarloGavazziEM24_E1Producer struct {
 	Opcodes
 }
 
-func NewCarloGavazziEM24Producer() Producer {
+func NewCarloGavazziEM24_E1Producer() Producer {
 	/***
 	 * Note: Carlo Gavazzi EM24 (RS-485 interface) and EM24_E1 (Ethernet interface)
 	 * have different register map.
-	 * Doc for EM24: https://www.ccontrols.com/support/dp/CarloGavazziEM24.pdf
+	 * Doc for EM24_E1: https://www.enika.eu/data/files/produkty/energy%20m/CP/em24%20ethernet%20cp.pdf
 	 */
 	ops := Opcodes{
 		VoltageL1: 0x00,
@@ -29,26 +29,26 @@ func NewCarloGavazziEM24Producer() Producer {
 		PowerL2:   0x14,
 		PowerL3:   0x16,
 		Power:     0x28,
-		CosphiL1:  0x32,
-		CosphiL2:  0x33,
-		CosphiL3:  0x34,
-		Cosphi:    0x35,
-		Frequency: 0x37,
-		Import:    0x42,
-		ImportL1:  0x46,
-		ImportL2:  0x48,
-		ImportL3:  0x4A,
-		Export:    0x5C,
+		CosphiL1:  0x2E,
+		CosphiL2:  0x2F,
+		CosphiL3:  0x30,
+		Cosphi:    0x31,
+		Frequency: 0x33,
+		Import:    0x34,
+		ImportL1:  0x40,
+		ImportL2:  0x42,
+		ImportL3:  0x44,
+		Export:    0x4E,
 	}
-	return &CarloGavazziEM24Producer{Opcodes: ops}
+	return &CarloGavazziEM24_E1Producer{Opcodes: ops}
 }
 
 // Description implements Producer interface
-func (p *CarloGavazziEM24Producer) Description() string {
-	return "Carlo Gavazzi EM24"
+func (p *CarloGavazziEM24_E1Producer) Description() string {
+	return "Carlo Gavazzi EM24_E1"
 }
 
-func (p *CarloGavazziEM24Producer) snip16(iec Measurement, scaler ...float64) Operation {
+func (p *CarloGavazziEM24_E1Producer) snip16(iec Measurement, scaler ...float64) Operation {
 	transform := RTUInt16ToFloat64 // default conversion
 	if len(scaler) > 0 {
 		transform = MakeScaledTransform(transform, scaler[0])
@@ -64,7 +64,7 @@ func (p *CarloGavazziEM24Producer) snip16(iec Measurement, scaler ...float64) Op
 	return operation
 }
 
-func (p *CarloGavazziEM24Producer) snip32(iec Measurement, scaler ...float64) Operation {
+func (p *CarloGavazziEM24_E1Producer) snip32(iec Measurement, scaler ...float64) Operation {
 	transform := RTUInt32ToFloat64Swapped // default conversion
 	if len(scaler) > 0 {
 		transform = MakeScaledTransform(transform, scaler[0])
@@ -81,12 +81,12 @@ func (p *CarloGavazziEM24Producer) snip32(iec Measurement, scaler ...float64) Op
 }
 
 // Probe implements Producer interface
-func (p *CarloGavazziEM24Producer) Probe() Operation {
+func (p *CarloGavazziEM24_E1Producer) Probe() Operation {
 	return p.snip32(VoltageL1, 10)
 }
 
 // Produce implements Producer interface
-func (p *CarloGavazziEM24Producer) Produce() (res []Operation) {
+func (p *CarloGavazziEM24_E1Producer) Produce() (res []Operation) {
 	for _, op := range []Measurement{
 		VoltageL1, VoltageL2, VoltageL3,
 	} {

--- a/meters/rs485/carlogavazzi-em24_e1.go
+++ b/meters/rs485/carlogavazzi-em24_e1.go
@@ -15,7 +15,6 @@ type CarloGavazziEM24_E1Producer struct {
 func NewCarloGavazziEM24_E1Producer() Producer {
 	/***
 	 * Note: Carlo Gavazzi EM24_E1 (Ethernet)
-	 * have different register map.
 	 * Doc for EM24_E1: https://www.enika.eu/data/files/produkty/energy%20m/CP/em24%20ethernet%20cp.pdf
 	 */
 	ops := Opcodes{


### PR DESCRIPTION
This is the version with adding EM24_E1

I opted to not share code with carlogavazzi-ex3x0.go ; although the code is practically the same, I think it would cause more confusion to try to share this.

Fixes: #317