### PR TITLE
ci: regenerate measurement enumer + run make assets in Build/Lint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,12 @@ jobs:
           cache: true
         id: go
 
+      - name: Install tools
+        run: make install
+
+      - name: Assets
+        run: make assets
+
       - name: Build
         run: make build
 
@@ -63,6 +69,12 @@ jobs:
           go-version-file: go.mod
           cache: true
         id: go
+
+      - name: Install tools
+        run: make install
+
+      - name: Assets
+        run: make assets
 
       - name: Lint
         uses: golangci/golangci-lint-action@v9

--- a/meters/measurement_enumer.go
+++ b/meters/measurement_enumer.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _MeasurementName = "FrequencyCurrentCurrentL1CurrentL2CurrentL3VoltageVoltageL1VoltageL2VoltageL3PowerPowerL1PowerL2PowerL3ImportPowerImportPowerL1ImportPowerL2ImportPowerL3ExportPowerExportPowerL1ExportPowerL2ExportPowerL3ReactivePowerReactivePowerL1ReactivePowerL2ReactivePowerL3ApparentPowerApparentPowerL1ApparentPowerL2ApparentPowerL3CosphiCosphiL1CosphiL2CosphiL3THDTHDL1THDL2THDL3SumSumT1SumT2SumL1SumL2SumL3ImportImportT1ImportT2ImportL1ImportL2ImportL3ExportExportT1ExportT2ExportL1ExportL2ExportL3ReactiveSumReactiveSumT1ReactiveSumT2ReactiveSumL1ReactiveSumL2ReactiveSumL3ReactiveImportReactiveImportT1ReactiveImportT2ReactiveImportL1ReactiveImportL2ReactiveImportL3ReactiveExportReactiveExportT1ReactiveExportT2ReactiveExportL1ReactiveExportL2ReactiveExportL3DCCurrentDCVoltageDCPowerHeatSinkTempDCCurrentS1DCVoltageS1DCPowerS1DCEnergyS1DCCurrentS2DCVoltageS2DCPowerS2DCEnergyS2DCCurrentS3DCVoltageS3DCPowerS3DCEnergyS3DCCurrentS4DCVoltageS4DCPowerS4DCEnergyS4ChargeStateBatteryVoltagePhaseAngle"
+const _MeasurementName = "FrequencyFrequencyL1FrequencyL2FrequencyL3CurrentCurrentL1CurrentL2CurrentL3VoltageVoltageL1VoltageL2VoltageL3VoltageL1_L2VoltageL2_L3VoltageL3_L1VoltageL_N_avgVoltageL_L_avgPowerPowerL1PowerL2PowerL3ImportPowerImportPowerL1ImportPowerL2ImportPowerL3ExportPowerExportPowerL1ExportPowerL2ExportPowerL3ReactivePowerReactivePowerL1ReactivePowerL2ReactivePowerL3ApparentPowerApparentPowerL1ApparentPowerL2ApparentPowerL3CosphiCosphiL1CosphiL2CosphiL3THDTHDL1THDL2THDL3ThreePhase_Vec_ASumSumT1SumT2SumL1SumL2SumL3ImportImportT1ImportT2ImportL1ImportL2ImportL3ExportExportT1ExportT2ExportL1ExportL2ExportL3ReactiveSumReactiveSumT1ReactiveSumT2ReactiveSumL1ReactiveSumL2ReactiveSumL3ReactiveImportReactiveImportT1ReactiveImportT2ReactiveImportL1ReactiveImportL2ReactiveImportL3ReactiveExportReactiveExportT1ReactiveExportT2ReactiveExportL1ReactiveExportL2ReactiveExportL3DCCurrentDCVoltageDCPowerHeatSinkTempDCCurrentS1DCVoltageS1DCPowerS1DCEnergyS1DCCurrentS2DCVoltageS2DCPowerS2DCEnergyS2DCCurrentS3DCVoltageS3DCPowerS3DCEnergyS3DCCurrentS4DCVoltageS4DCPowerS4DCEnergyS4ChargeStateBatteryVoltagePhaseAngle"
 
-var _MeasurementIndex = [...]uint16{0, 9, 16, 25, 34, 43, 50, 59, 68, 77, 82, 89, 96, 103, 114, 127, 140, 153, 164, 177, 190, 203, 216, 231, 246, 261, 274, 289, 304, 319, 325, 333, 341, 349, 352, 357, 362, 367, 370, 375, 380, 385, 390, 395, 401, 409, 417, 425, 433, 441, 447, 455, 463, 471, 479, 487, 498, 511, 524, 537, 550, 563, 577, 593, 609, 625, 641, 657, 671, 687, 703, 719, 735, 751, 760, 769, 776, 788, 799, 810, 819, 829, 840, 851, 860, 870, 881, 892, 901, 911, 922, 933, 942, 952, 963, 977, 987}
+var _MeasurementIndex = [...]uint16{0, 9, 20, 31, 42, 49, 58, 67, 76, 83, 92, 101, 110, 122, 134, 146, 160, 174, 179, 186, 193, 200, 211, 224, 237, 250, 261, 274, 287, 300, 313, 328, 343, 358, 371, 386, 401, 416, 422, 430, 438, 446, 449, 454, 459, 464, 480, 483, 488, 493, 498, 503, 508, 514, 522, 530, 538, 546, 554, 560, 568, 576, 584, 592, 600, 611, 624, 637, 650, 663, 676, 690, 706, 722, 738, 754, 770, 784, 800, 816, 832, 848, 864, 873, 882, 889, 901, 912, 923, 932, 942, 953, 964, 973, 983, 994, 1005, 1014, 1024, 1035, 1046, 1055, 1065, 1076, 1090, 1100}
 
-const _MeasurementLowerName = "frequencycurrentcurrentl1currentl2currentl3voltagevoltagel1voltagel2voltagel3powerpowerl1powerl2powerl3importpowerimportpowerl1importpowerl2importpowerl3exportpowerexportpowerl1exportpowerl2exportpowerl3reactivepowerreactivepowerl1reactivepowerl2reactivepowerl3apparentpowerapparentpowerl1apparentpowerl2apparentpowerl3cosphicosphil1cosphil2cosphil3thdthdl1thdl2thdl3sumsumt1sumt2suml1suml2suml3importimportt1importt2importl1importl2importl3exportexportt1exportt2exportl1exportl2exportl3reactivesumreactivesumt1reactivesumt2reactivesuml1reactivesuml2reactivesuml3reactiveimportreactiveimportt1reactiveimportt2reactiveimportl1reactiveimportl2reactiveimportl3reactiveexportreactiveexportt1reactiveexportt2reactiveexportl1reactiveexportl2reactiveexportl3dccurrentdcvoltagedcpowerheatsinktempdccurrents1dcvoltages1dcpowers1dcenergys1dccurrents2dcvoltages2dcpowers2dcenergys2dccurrents3dcvoltages3dcpowers3dcenergys3dccurrents4dcvoltages4dcpowers4dcenergys4chargestatebatteryvoltagephaseangle"
+const _MeasurementLowerName = "frequencyfrequencyl1frequencyl2frequencyl3currentcurrentl1currentl2currentl3voltagevoltagel1voltagel2voltagel3voltagel1_l2voltagel2_l3voltagel3_l1voltagel_n_avgvoltagel_l_avgpowerpowerl1powerl2powerl3importpowerimportpowerl1importpowerl2importpowerl3exportpowerexportpowerl1exportpowerl2exportpowerl3reactivepowerreactivepowerl1reactivepowerl2reactivepowerl3apparentpowerapparentpowerl1apparentpowerl2apparentpowerl3cosphicosphil1cosphil2cosphil3thdthdl1thdl2thdl3threephase_vec_asumsumt1sumt2suml1suml2suml3importimportt1importt2importl1importl2importl3exportexportt1exportt2exportl1exportl2exportl3reactivesumreactivesumt1reactivesumt2reactivesuml1reactivesuml2reactivesuml3reactiveimportreactiveimportt1reactiveimportt2reactiveimportl1reactiveimportl2reactiveimportl3reactiveexportreactiveexportt1reactiveexportt2reactiveexportl1reactiveexportl2reactiveexportl3dccurrentdcvoltagedcpowerheatsinktempdccurrents1dcvoltages1dcpowers1dcenergys1dccurrents2dcvoltages2dcpowers2dcenergys2dccurrents3dcvoltages3dcpowers3dcenergys3dccurrents4dcvoltages4dcpowers4dcenergys4chargestatebatteryvoltagephaseangle"
 
 func (i Measurement) String() string {
 	i -= 1
@@ -26,397 +26,433 @@ func (i Measurement) String() string {
 func _MeasurementNoOp() {
 	var x [1]struct{}
 	_ = x[Frequency-(1)]
-	_ = x[Current-(2)]
-	_ = x[CurrentL1-(3)]
-	_ = x[CurrentL2-(4)]
-	_ = x[CurrentL3-(5)]
-	_ = x[Voltage-(6)]
-	_ = x[VoltageL1-(7)]
-	_ = x[VoltageL2-(8)]
-	_ = x[VoltageL3-(9)]
-	_ = x[Power-(10)]
-	_ = x[PowerL1-(11)]
-	_ = x[PowerL2-(12)]
-	_ = x[PowerL3-(13)]
-	_ = x[ImportPower-(14)]
-	_ = x[ImportPowerL1-(15)]
-	_ = x[ImportPowerL2-(16)]
-	_ = x[ImportPowerL3-(17)]
-	_ = x[ExportPower-(18)]
-	_ = x[ExportPowerL1-(19)]
-	_ = x[ExportPowerL2-(20)]
-	_ = x[ExportPowerL3-(21)]
-	_ = x[ReactivePower-(22)]
-	_ = x[ReactivePowerL1-(23)]
-	_ = x[ReactivePowerL2-(24)]
-	_ = x[ReactivePowerL3-(25)]
-	_ = x[ApparentPower-(26)]
-	_ = x[ApparentPowerL1-(27)]
-	_ = x[ApparentPowerL2-(28)]
-	_ = x[ApparentPowerL3-(29)]
-	_ = x[Cosphi-(30)]
-	_ = x[CosphiL1-(31)]
-	_ = x[CosphiL2-(32)]
-	_ = x[CosphiL3-(33)]
-	_ = x[THD-(34)]
-	_ = x[THDL1-(35)]
-	_ = x[THDL2-(36)]
-	_ = x[THDL3-(37)]
-	_ = x[Sum-(38)]
-	_ = x[SumT1-(39)]
-	_ = x[SumT2-(40)]
-	_ = x[SumL1-(41)]
-	_ = x[SumL2-(42)]
-	_ = x[SumL3-(43)]
-	_ = x[Import-(44)]
-	_ = x[ImportT1-(45)]
-	_ = x[ImportT2-(46)]
-	_ = x[ImportL1-(47)]
-	_ = x[ImportL2-(48)]
-	_ = x[ImportL3-(49)]
-	_ = x[Export-(50)]
-	_ = x[ExportT1-(51)]
-	_ = x[ExportT2-(52)]
-	_ = x[ExportL1-(53)]
-	_ = x[ExportL2-(54)]
-	_ = x[ExportL3-(55)]
-	_ = x[ReactiveSum-(56)]
-	_ = x[ReactiveSumT1-(57)]
-	_ = x[ReactiveSumT2-(58)]
-	_ = x[ReactiveSumL1-(59)]
-	_ = x[ReactiveSumL2-(60)]
-	_ = x[ReactiveSumL3-(61)]
-	_ = x[ReactiveImport-(62)]
-	_ = x[ReactiveImportT1-(63)]
-	_ = x[ReactiveImportT2-(64)]
-	_ = x[ReactiveImportL1-(65)]
-	_ = x[ReactiveImportL2-(66)]
-	_ = x[ReactiveImportL3-(67)]
-	_ = x[ReactiveExport-(68)]
-	_ = x[ReactiveExportT1-(69)]
-	_ = x[ReactiveExportT2-(70)]
-	_ = x[ReactiveExportL1-(71)]
-	_ = x[ReactiveExportL2-(72)]
-	_ = x[ReactiveExportL3-(73)]
-	_ = x[DCCurrent-(74)]
-	_ = x[DCVoltage-(75)]
-	_ = x[DCPower-(76)]
-	_ = x[HeatSinkTemp-(77)]
-	_ = x[DCCurrentS1-(78)]
-	_ = x[DCVoltageS1-(79)]
-	_ = x[DCPowerS1-(80)]
-	_ = x[DCEnergyS1-(81)]
-	_ = x[DCCurrentS2-(82)]
-	_ = x[DCVoltageS2-(83)]
-	_ = x[DCPowerS2-(84)]
-	_ = x[DCEnergyS2-(85)]
-	_ = x[DCCurrentS3-(86)]
-	_ = x[DCVoltageS3-(87)]
-	_ = x[DCPowerS3-(88)]
-	_ = x[DCEnergyS3-(89)]
-	_ = x[DCCurrentS4-(90)]
-	_ = x[DCVoltageS4-(91)]
-	_ = x[DCPowerS4-(92)]
-	_ = x[DCEnergyS4-(93)]
-	_ = x[ChargeState-(94)]
-	_ = x[BatteryVoltage-(95)]
-	_ = x[PhaseAngle-(96)]
+	_ = x[FrequencyL1-(2)]
+	_ = x[FrequencyL2-(3)]
+	_ = x[FrequencyL3-(4)]
+	_ = x[Current-(5)]
+	_ = x[CurrentL1-(6)]
+	_ = x[CurrentL2-(7)]
+	_ = x[CurrentL3-(8)]
+	_ = x[Voltage-(9)]
+	_ = x[VoltageL1-(10)]
+	_ = x[VoltageL2-(11)]
+	_ = x[VoltageL3-(12)]
+	_ = x[VoltageL1_L2-(13)]
+	_ = x[VoltageL2_L3-(14)]
+	_ = x[VoltageL3_L1-(15)]
+	_ = x[VoltageL_N_avg-(16)]
+	_ = x[VoltageL_L_avg-(17)]
+	_ = x[Power-(18)]
+	_ = x[PowerL1-(19)]
+	_ = x[PowerL2-(20)]
+	_ = x[PowerL3-(21)]
+	_ = x[ImportPower-(22)]
+	_ = x[ImportPowerL1-(23)]
+	_ = x[ImportPowerL2-(24)]
+	_ = x[ImportPowerL3-(25)]
+	_ = x[ExportPower-(26)]
+	_ = x[ExportPowerL1-(27)]
+	_ = x[ExportPowerL2-(28)]
+	_ = x[ExportPowerL3-(29)]
+	_ = x[ReactivePower-(30)]
+	_ = x[ReactivePowerL1-(31)]
+	_ = x[ReactivePowerL2-(32)]
+	_ = x[ReactivePowerL3-(33)]
+	_ = x[ApparentPower-(34)]
+	_ = x[ApparentPowerL1-(35)]
+	_ = x[ApparentPowerL2-(36)]
+	_ = x[ApparentPowerL3-(37)]
+	_ = x[Cosphi-(38)]
+	_ = x[CosphiL1-(39)]
+	_ = x[CosphiL2-(40)]
+	_ = x[CosphiL3-(41)]
+	_ = x[THD-(42)]
+	_ = x[THDL1-(43)]
+	_ = x[THDL2-(44)]
+	_ = x[THDL3-(45)]
+	_ = x[ThreePhase_Vec_A-(46)]
+	_ = x[Sum-(47)]
+	_ = x[SumT1-(48)]
+	_ = x[SumT2-(49)]
+	_ = x[SumL1-(50)]
+	_ = x[SumL2-(51)]
+	_ = x[SumL3-(52)]
+	_ = x[Import-(53)]
+	_ = x[ImportT1-(54)]
+	_ = x[ImportT2-(55)]
+	_ = x[ImportL1-(56)]
+	_ = x[ImportL2-(57)]
+	_ = x[ImportL3-(58)]
+	_ = x[Export-(59)]
+	_ = x[ExportT1-(60)]
+	_ = x[ExportT2-(61)]
+	_ = x[ExportL1-(62)]
+	_ = x[ExportL2-(63)]
+	_ = x[ExportL3-(64)]
+	_ = x[ReactiveSum-(65)]
+	_ = x[ReactiveSumT1-(66)]
+	_ = x[ReactiveSumT2-(67)]
+	_ = x[ReactiveSumL1-(68)]
+	_ = x[ReactiveSumL2-(69)]
+	_ = x[ReactiveSumL3-(70)]
+	_ = x[ReactiveImport-(71)]
+	_ = x[ReactiveImportT1-(72)]
+	_ = x[ReactiveImportT2-(73)]
+	_ = x[ReactiveImportL1-(74)]
+	_ = x[ReactiveImportL2-(75)]
+	_ = x[ReactiveImportL3-(76)]
+	_ = x[ReactiveExport-(77)]
+	_ = x[ReactiveExportT1-(78)]
+	_ = x[ReactiveExportT2-(79)]
+	_ = x[ReactiveExportL1-(80)]
+	_ = x[ReactiveExportL2-(81)]
+	_ = x[ReactiveExportL3-(82)]
+	_ = x[DCCurrent-(83)]
+	_ = x[DCVoltage-(84)]
+	_ = x[DCPower-(85)]
+	_ = x[HeatSinkTemp-(86)]
+	_ = x[DCCurrentS1-(87)]
+	_ = x[DCVoltageS1-(88)]
+	_ = x[DCPowerS1-(89)]
+	_ = x[DCEnergyS1-(90)]
+	_ = x[DCCurrentS2-(91)]
+	_ = x[DCVoltageS2-(92)]
+	_ = x[DCPowerS2-(93)]
+	_ = x[DCEnergyS2-(94)]
+	_ = x[DCCurrentS3-(95)]
+	_ = x[DCVoltageS3-(96)]
+	_ = x[DCPowerS3-(97)]
+	_ = x[DCEnergyS3-(98)]
+	_ = x[DCCurrentS4-(99)]
+	_ = x[DCVoltageS4-(100)]
+	_ = x[DCPowerS4-(101)]
+	_ = x[DCEnergyS4-(102)]
+	_ = x[ChargeState-(103)]
+	_ = x[BatteryVoltage-(104)]
+	_ = x[PhaseAngle-(105)]
 }
 
-var _MeasurementValues = []Measurement{Frequency, Current, CurrentL1, CurrentL2, CurrentL3, Voltage, VoltageL1, VoltageL2, VoltageL3, Power, PowerL1, PowerL2, PowerL3, ImportPower, ImportPowerL1, ImportPowerL2, ImportPowerL3, ExportPower, ExportPowerL1, ExportPowerL2, ExportPowerL3, ReactivePower, ReactivePowerL1, ReactivePowerL2, ReactivePowerL3, ApparentPower, ApparentPowerL1, ApparentPowerL2, ApparentPowerL3, Cosphi, CosphiL1, CosphiL2, CosphiL3, THD, THDL1, THDL2, THDL3, Sum, SumT1, SumT2, SumL1, SumL2, SumL3, Import, ImportT1, ImportT2, ImportL1, ImportL2, ImportL3, Export, ExportT1, ExportT2, ExportL1, ExportL2, ExportL3, ReactiveSum, ReactiveSumT1, ReactiveSumT2, ReactiveSumL1, ReactiveSumL2, ReactiveSumL3, ReactiveImport, ReactiveImportT1, ReactiveImportT2, ReactiveImportL1, ReactiveImportL2, ReactiveImportL3, ReactiveExport, ReactiveExportT1, ReactiveExportT2, ReactiveExportL1, ReactiveExportL2, ReactiveExportL3, DCCurrent, DCVoltage, DCPower, HeatSinkTemp, DCCurrentS1, DCVoltageS1, DCPowerS1, DCEnergyS1, DCCurrentS2, DCVoltageS2, DCPowerS2, DCEnergyS2, DCCurrentS3, DCVoltageS3, DCPowerS3, DCEnergyS3, DCCurrentS4, DCVoltageS4, DCPowerS4, DCEnergyS4, ChargeState, BatteryVoltage, PhaseAngle}
+var _MeasurementValues = []Measurement{Frequency, FrequencyL1, FrequencyL2, FrequencyL3, Current, CurrentL1, CurrentL2, CurrentL3, Voltage, VoltageL1, VoltageL2, VoltageL3, VoltageL1_L2, VoltageL2_L3, VoltageL3_L1, VoltageL_N_avg, VoltageL_L_avg, Power, PowerL1, PowerL2, PowerL3, ImportPower, ImportPowerL1, ImportPowerL2, ImportPowerL3, ExportPower, ExportPowerL1, ExportPowerL2, ExportPowerL3, ReactivePower, ReactivePowerL1, ReactivePowerL2, ReactivePowerL3, ApparentPower, ApparentPowerL1, ApparentPowerL2, ApparentPowerL3, Cosphi, CosphiL1, CosphiL2, CosphiL3, THD, THDL1, THDL2, THDL3, ThreePhase_Vec_A, Sum, SumT1, SumT2, SumL1, SumL2, SumL3, Import, ImportT1, ImportT2, ImportL1, ImportL2, ImportL3, Export, ExportT1, ExportT2, ExportL1, ExportL2, ExportL3, ReactiveSum, ReactiveSumT1, ReactiveSumT2, ReactiveSumL1, ReactiveSumL2, ReactiveSumL3, ReactiveImport, ReactiveImportT1, ReactiveImportT2, ReactiveImportL1, ReactiveImportL2, ReactiveImportL3, ReactiveExport, ReactiveExportT1, ReactiveExportT2, ReactiveExportL1, ReactiveExportL2, ReactiveExportL3, DCCurrent, DCVoltage, DCPower, HeatSinkTemp, DCCurrentS1, DCVoltageS1, DCPowerS1, DCEnergyS1, DCCurrentS2, DCVoltageS2, DCPowerS2, DCEnergyS2, DCCurrentS3, DCVoltageS3, DCPowerS3, DCEnergyS3, DCCurrentS4, DCVoltageS4, DCPowerS4, DCEnergyS4, ChargeState, BatteryVoltage, PhaseAngle}
 
 var _MeasurementNameToValueMap = map[string]Measurement{
-	_MeasurementName[0:9]:          Frequency,
-	_MeasurementLowerName[0:9]:     Frequency,
-	_MeasurementName[9:16]:         Current,
-	_MeasurementLowerName[9:16]:    Current,
-	_MeasurementName[16:25]:        CurrentL1,
-	_MeasurementLowerName[16:25]:   CurrentL1,
-	_MeasurementName[25:34]:        CurrentL2,
-	_MeasurementLowerName[25:34]:   CurrentL2,
-	_MeasurementName[34:43]:        CurrentL3,
-	_MeasurementLowerName[34:43]:   CurrentL3,
-	_MeasurementName[43:50]:        Voltage,
-	_MeasurementLowerName[43:50]:   Voltage,
-	_MeasurementName[50:59]:        VoltageL1,
-	_MeasurementLowerName[50:59]:   VoltageL1,
-	_MeasurementName[59:68]:        VoltageL2,
-	_MeasurementLowerName[59:68]:   VoltageL2,
-	_MeasurementName[68:77]:        VoltageL3,
-	_MeasurementLowerName[68:77]:   VoltageL3,
-	_MeasurementName[77:82]:        Power,
-	_MeasurementLowerName[77:82]:   Power,
-	_MeasurementName[82:89]:        PowerL1,
-	_MeasurementLowerName[82:89]:   PowerL1,
-	_MeasurementName[89:96]:        PowerL2,
-	_MeasurementLowerName[89:96]:   PowerL2,
-	_MeasurementName[96:103]:       PowerL3,
-	_MeasurementLowerName[96:103]:  PowerL3,
-	_MeasurementName[103:114]:      ImportPower,
-	_MeasurementLowerName[103:114]: ImportPower,
-	_MeasurementName[114:127]:      ImportPowerL1,
-	_MeasurementLowerName[114:127]: ImportPowerL1,
-	_MeasurementName[127:140]:      ImportPowerL2,
-	_MeasurementLowerName[127:140]: ImportPowerL2,
-	_MeasurementName[140:153]:      ImportPowerL3,
-	_MeasurementLowerName[140:153]: ImportPowerL3,
-	_MeasurementName[153:164]:      ExportPower,
-	_MeasurementLowerName[153:164]: ExportPower,
-	_MeasurementName[164:177]:      ExportPowerL1,
-	_MeasurementLowerName[164:177]: ExportPowerL1,
-	_MeasurementName[177:190]:      ExportPowerL2,
-	_MeasurementLowerName[177:190]: ExportPowerL2,
-	_MeasurementName[190:203]:      ExportPowerL3,
-	_MeasurementLowerName[190:203]: ExportPowerL3,
-	_MeasurementName[203:216]:      ReactivePower,
-	_MeasurementLowerName[203:216]: ReactivePower,
-	_MeasurementName[216:231]:      ReactivePowerL1,
-	_MeasurementLowerName[216:231]: ReactivePowerL1,
-	_MeasurementName[231:246]:      ReactivePowerL2,
-	_MeasurementLowerName[231:246]: ReactivePowerL2,
-	_MeasurementName[246:261]:      ReactivePowerL3,
-	_MeasurementLowerName[246:261]: ReactivePowerL3,
-	_MeasurementName[261:274]:      ApparentPower,
-	_MeasurementLowerName[261:274]: ApparentPower,
-	_MeasurementName[274:289]:      ApparentPowerL1,
-	_MeasurementLowerName[274:289]: ApparentPowerL1,
-	_MeasurementName[289:304]:      ApparentPowerL2,
-	_MeasurementLowerName[289:304]: ApparentPowerL2,
-	_MeasurementName[304:319]:      ApparentPowerL3,
-	_MeasurementLowerName[304:319]: ApparentPowerL3,
-	_MeasurementName[319:325]:      Cosphi,
-	_MeasurementLowerName[319:325]: Cosphi,
-	_MeasurementName[325:333]:      CosphiL1,
-	_MeasurementLowerName[325:333]: CosphiL1,
-	_MeasurementName[333:341]:      CosphiL2,
-	_MeasurementLowerName[333:341]: CosphiL2,
-	_MeasurementName[341:349]:      CosphiL3,
-	_MeasurementLowerName[341:349]: CosphiL3,
-	_MeasurementName[349:352]:      THD,
-	_MeasurementLowerName[349:352]: THD,
-	_MeasurementName[352:357]:      THDL1,
-	_MeasurementLowerName[352:357]: THDL1,
-	_MeasurementName[357:362]:      THDL2,
-	_MeasurementLowerName[357:362]: THDL2,
-	_MeasurementName[362:367]:      THDL3,
-	_MeasurementLowerName[362:367]: THDL3,
-	_MeasurementName[367:370]:      Sum,
-	_MeasurementLowerName[367:370]: Sum,
-	_MeasurementName[370:375]:      SumT1,
-	_MeasurementLowerName[370:375]: SumT1,
-	_MeasurementName[375:380]:      SumT2,
-	_MeasurementLowerName[375:380]: SumT2,
-	_MeasurementName[380:385]:      SumL1,
-	_MeasurementLowerName[380:385]: SumL1,
-	_MeasurementName[385:390]:      SumL2,
-	_MeasurementLowerName[385:390]: SumL2,
-	_MeasurementName[390:395]:      SumL3,
-	_MeasurementLowerName[390:395]: SumL3,
-	_MeasurementName[395:401]:      Import,
-	_MeasurementLowerName[395:401]: Import,
-	_MeasurementName[401:409]:      ImportT1,
-	_MeasurementLowerName[401:409]: ImportT1,
-	_MeasurementName[409:417]:      ImportT2,
-	_MeasurementLowerName[409:417]: ImportT2,
-	_MeasurementName[417:425]:      ImportL1,
-	_MeasurementLowerName[417:425]: ImportL1,
-	_MeasurementName[425:433]:      ImportL2,
-	_MeasurementLowerName[425:433]: ImportL2,
-	_MeasurementName[433:441]:      ImportL3,
-	_MeasurementLowerName[433:441]: ImportL3,
-	_MeasurementName[441:447]:      Export,
-	_MeasurementLowerName[441:447]: Export,
-	_MeasurementName[447:455]:      ExportT1,
-	_MeasurementLowerName[447:455]: ExportT1,
-	_MeasurementName[455:463]:      ExportT2,
-	_MeasurementLowerName[455:463]: ExportT2,
-	_MeasurementName[463:471]:      ExportL1,
-	_MeasurementLowerName[463:471]: ExportL1,
-	_MeasurementName[471:479]:      ExportL2,
-	_MeasurementLowerName[471:479]: ExportL2,
-	_MeasurementName[479:487]:      ExportL3,
-	_MeasurementLowerName[479:487]: ExportL3,
-	_MeasurementName[487:498]:      ReactiveSum,
-	_MeasurementLowerName[487:498]: ReactiveSum,
-	_MeasurementName[498:511]:      ReactiveSumT1,
-	_MeasurementLowerName[498:511]: ReactiveSumT1,
-	_MeasurementName[511:524]:      ReactiveSumT2,
-	_MeasurementLowerName[511:524]: ReactiveSumT2,
-	_MeasurementName[524:537]:      ReactiveSumL1,
-	_MeasurementLowerName[524:537]: ReactiveSumL1,
-	_MeasurementName[537:550]:      ReactiveSumL2,
-	_MeasurementLowerName[537:550]: ReactiveSumL2,
-	_MeasurementName[550:563]:      ReactiveSumL3,
-	_MeasurementLowerName[550:563]: ReactiveSumL3,
-	_MeasurementName[563:577]:      ReactiveImport,
-	_MeasurementLowerName[563:577]: ReactiveImport,
-	_MeasurementName[577:593]:      ReactiveImportT1,
-	_MeasurementLowerName[577:593]: ReactiveImportT1,
-	_MeasurementName[593:609]:      ReactiveImportT2,
-	_MeasurementLowerName[593:609]: ReactiveImportT2,
-	_MeasurementName[609:625]:      ReactiveImportL1,
-	_MeasurementLowerName[609:625]: ReactiveImportL1,
-	_MeasurementName[625:641]:      ReactiveImportL2,
-	_MeasurementLowerName[625:641]: ReactiveImportL2,
-	_MeasurementName[641:657]:      ReactiveImportL3,
-	_MeasurementLowerName[641:657]: ReactiveImportL3,
-	_MeasurementName[657:671]:      ReactiveExport,
-	_MeasurementLowerName[657:671]: ReactiveExport,
-	_MeasurementName[671:687]:      ReactiveExportT1,
-	_MeasurementLowerName[671:687]: ReactiveExportT1,
-	_MeasurementName[687:703]:      ReactiveExportT2,
-	_MeasurementLowerName[687:703]: ReactiveExportT2,
-	_MeasurementName[703:719]:      ReactiveExportL1,
-	_MeasurementLowerName[703:719]: ReactiveExportL1,
-	_MeasurementName[719:735]:      ReactiveExportL2,
-	_MeasurementLowerName[719:735]: ReactiveExportL2,
-	_MeasurementName[735:751]:      ReactiveExportL3,
-	_MeasurementLowerName[735:751]: ReactiveExportL3,
-	_MeasurementName[751:760]:      DCCurrent,
-	_MeasurementLowerName[751:760]: DCCurrent,
-	_MeasurementName[760:769]:      DCVoltage,
-	_MeasurementLowerName[760:769]: DCVoltage,
-	_MeasurementName[769:776]:      DCPower,
-	_MeasurementLowerName[769:776]: DCPower,
-	_MeasurementName[776:788]:      HeatSinkTemp,
-	_MeasurementLowerName[776:788]: HeatSinkTemp,
-	_MeasurementName[788:799]:      DCCurrentS1,
-	_MeasurementLowerName[788:799]: DCCurrentS1,
-	_MeasurementName[799:810]:      DCVoltageS1,
-	_MeasurementLowerName[799:810]: DCVoltageS1,
-	_MeasurementName[810:819]:      DCPowerS1,
-	_MeasurementLowerName[810:819]: DCPowerS1,
-	_MeasurementName[819:829]:      DCEnergyS1,
-	_MeasurementLowerName[819:829]: DCEnergyS1,
-	_MeasurementName[829:840]:      DCCurrentS2,
-	_MeasurementLowerName[829:840]: DCCurrentS2,
-	_MeasurementName[840:851]:      DCVoltageS2,
-	_MeasurementLowerName[840:851]: DCVoltageS2,
-	_MeasurementName[851:860]:      DCPowerS2,
-	_MeasurementLowerName[851:860]: DCPowerS2,
-	_MeasurementName[860:870]:      DCEnergyS2,
-	_MeasurementLowerName[860:870]: DCEnergyS2,
-	_MeasurementName[870:881]:      DCCurrentS3,
-	_MeasurementLowerName[870:881]: DCCurrentS3,
-	_MeasurementName[881:892]:      DCVoltageS3,
-	_MeasurementLowerName[881:892]: DCVoltageS3,
-	_MeasurementName[892:901]:      DCPowerS3,
-	_MeasurementLowerName[892:901]: DCPowerS3,
-	_MeasurementName[901:911]:      DCEnergyS3,
-	_MeasurementLowerName[901:911]: DCEnergyS3,
-	_MeasurementName[911:922]:      DCCurrentS4,
-	_MeasurementLowerName[911:922]: DCCurrentS4,
-	_MeasurementName[922:933]:      DCVoltageS4,
-	_MeasurementLowerName[922:933]: DCVoltageS4,
-	_MeasurementName[933:942]:      DCPowerS4,
-	_MeasurementLowerName[933:942]: DCPowerS4,
-	_MeasurementName[942:952]:      DCEnergyS4,
-	_MeasurementLowerName[942:952]: DCEnergyS4,
-	_MeasurementName[952:963]:      ChargeState,
-	_MeasurementLowerName[952:963]: ChargeState,
-	_MeasurementName[963:977]:      BatteryVoltage,
-	_MeasurementLowerName[963:977]: BatteryVoltage,
-	_MeasurementName[977:987]:      PhaseAngle,
-	_MeasurementLowerName[977:987]: PhaseAngle,
+	_MeasurementName[0:9]:            Frequency,
+	_MeasurementLowerName[0:9]:       Frequency,
+	_MeasurementName[9:20]:           FrequencyL1,
+	_MeasurementLowerName[9:20]:      FrequencyL1,
+	_MeasurementName[20:31]:          FrequencyL2,
+	_MeasurementLowerName[20:31]:     FrequencyL2,
+	_MeasurementName[31:42]:          FrequencyL3,
+	_MeasurementLowerName[31:42]:     FrequencyL3,
+	_MeasurementName[42:49]:          Current,
+	_MeasurementLowerName[42:49]:     Current,
+	_MeasurementName[49:58]:          CurrentL1,
+	_MeasurementLowerName[49:58]:     CurrentL1,
+	_MeasurementName[58:67]:          CurrentL2,
+	_MeasurementLowerName[58:67]:     CurrentL2,
+	_MeasurementName[67:76]:          CurrentL3,
+	_MeasurementLowerName[67:76]:     CurrentL3,
+	_MeasurementName[76:83]:          Voltage,
+	_MeasurementLowerName[76:83]:     Voltage,
+	_MeasurementName[83:92]:          VoltageL1,
+	_MeasurementLowerName[83:92]:     VoltageL1,
+	_MeasurementName[92:101]:         VoltageL2,
+	_MeasurementLowerName[92:101]:    VoltageL2,
+	_MeasurementName[101:110]:        VoltageL3,
+	_MeasurementLowerName[101:110]:   VoltageL3,
+	_MeasurementName[110:122]:        VoltageL1_L2,
+	_MeasurementLowerName[110:122]:   VoltageL1_L2,
+	_MeasurementName[122:134]:        VoltageL2_L3,
+	_MeasurementLowerName[122:134]:   VoltageL2_L3,
+	_MeasurementName[134:146]:        VoltageL3_L1,
+	_MeasurementLowerName[134:146]:   VoltageL3_L1,
+	_MeasurementName[146:160]:        VoltageL_N_avg,
+	_MeasurementLowerName[146:160]:   VoltageL_N_avg,
+	_MeasurementName[160:174]:        VoltageL_L_avg,
+	_MeasurementLowerName[160:174]:   VoltageL_L_avg,
+	_MeasurementName[174:179]:        Power,
+	_MeasurementLowerName[174:179]:   Power,
+	_MeasurementName[179:186]:        PowerL1,
+	_MeasurementLowerName[179:186]:   PowerL1,
+	_MeasurementName[186:193]:        PowerL2,
+	_MeasurementLowerName[186:193]:   PowerL2,
+	_MeasurementName[193:200]:        PowerL3,
+	_MeasurementLowerName[193:200]:   PowerL3,
+	_MeasurementName[200:211]:        ImportPower,
+	_MeasurementLowerName[200:211]:   ImportPower,
+	_MeasurementName[211:224]:        ImportPowerL1,
+	_MeasurementLowerName[211:224]:   ImportPowerL1,
+	_MeasurementName[224:237]:        ImportPowerL2,
+	_MeasurementLowerName[224:237]:   ImportPowerL2,
+	_MeasurementName[237:250]:        ImportPowerL3,
+	_MeasurementLowerName[237:250]:   ImportPowerL3,
+	_MeasurementName[250:261]:        ExportPower,
+	_MeasurementLowerName[250:261]:   ExportPower,
+	_MeasurementName[261:274]:        ExportPowerL1,
+	_MeasurementLowerName[261:274]:   ExportPowerL1,
+	_MeasurementName[274:287]:        ExportPowerL2,
+	_MeasurementLowerName[274:287]:   ExportPowerL2,
+	_MeasurementName[287:300]:        ExportPowerL3,
+	_MeasurementLowerName[287:300]:   ExportPowerL3,
+	_MeasurementName[300:313]:        ReactivePower,
+	_MeasurementLowerName[300:313]:   ReactivePower,
+	_MeasurementName[313:328]:        ReactivePowerL1,
+	_MeasurementLowerName[313:328]:   ReactivePowerL1,
+	_MeasurementName[328:343]:        ReactivePowerL2,
+	_MeasurementLowerName[328:343]:   ReactivePowerL2,
+	_MeasurementName[343:358]:        ReactivePowerL3,
+	_MeasurementLowerName[343:358]:   ReactivePowerL3,
+	_MeasurementName[358:371]:        ApparentPower,
+	_MeasurementLowerName[358:371]:   ApparentPower,
+	_MeasurementName[371:386]:        ApparentPowerL1,
+	_MeasurementLowerName[371:386]:   ApparentPowerL1,
+	_MeasurementName[386:401]:        ApparentPowerL2,
+	_MeasurementLowerName[386:401]:   ApparentPowerL2,
+	_MeasurementName[401:416]:        ApparentPowerL3,
+	_MeasurementLowerName[401:416]:   ApparentPowerL3,
+	_MeasurementName[416:422]:        Cosphi,
+	_MeasurementLowerName[416:422]:   Cosphi,
+	_MeasurementName[422:430]:        CosphiL1,
+	_MeasurementLowerName[422:430]:   CosphiL1,
+	_MeasurementName[430:438]:        CosphiL2,
+	_MeasurementLowerName[430:438]:   CosphiL2,
+	_MeasurementName[438:446]:        CosphiL3,
+	_MeasurementLowerName[438:446]:   CosphiL3,
+	_MeasurementName[446:449]:        THD,
+	_MeasurementLowerName[446:449]:   THD,
+	_MeasurementName[449:454]:        THDL1,
+	_MeasurementLowerName[449:454]:   THDL1,
+	_MeasurementName[454:459]:        THDL2,
+	_MeasurementLowerName[454:459]:   THDL2,
+	_MeasurementName[459:464]:        THDL3,
+	_MeasurementLowerName[459:464]:   THDL3,
+	_MeasurementName[464:480]:        ThreePhase_Vec_A,
+	_MeasurementLowerName[464:480]:   ThreePhase_Vec_A,
+	_MeasurementName[480:483]:        Sum,
+	_MeasurementLowerName[480:483]:   Sum,
+	_MeasurementName[483:488]:        SumT1,
+	_MeasurementLowerName[483:488]:   SumT1,
+	_MeasurementName[488:493]:        SumT2,
+	_MeasurementLowerName[488:493]:   SumT2,
+	_MeasurementName[493:498]:        SumL1,
+	_MeasurementLowerName[493:498]:   SumL1,
+	_MeasurementName[498:503]:        SumL2,
+	_MeasurementLowerName[498:503]:   SumL2,
+	_MeasurementName[503:508]:        SumL3,
+	_MeasurementLowerName[503:508]:   SumL3,
+	_MeasurementName[508:514]:        Import,
+	_MeasurementLowerName[508:514]:   Import,
+	_MeasurementName[514:522]:        ImportT1,
+	_MeasurementLowerName[514:522]:   ImportT1,
+	_MeasurementName[522:530]:        ImportT2,
+	_MeasurementLowerName[522:530]:   ImportT2,
+	_MeasurementName[530:538]:        ImportL1,
+	_MeasurementLowerName[530:538]:   ImportL1,
+	_MeasurementName[538:546]:        ImportL2,
+	_MeasurementLowerName[538:546]:   ImportL2,
+	_MeasurementName[546:554]:        ImportL3,
+	_MeasurementLowerName[546:554]:   ImportL3,
+	_MeasurementName[554:560]:        Export,
+	_MeasurementLowerName[554:560]:   Export,
+	_MeasurementName[560:568]:        ExportT1,
+	_MeasurementLowerName[560:568]:   ExportT1,
+	_MeasurementName[568:576]:        ExportT2,
+	_MeasurementLowerName[568:576]:   ExportT2,
+	_MeasurementName[576:584]:        ExportL1,
+	_MeasurementLowerName[576:584]:   ExportL1,
+	_MeasurementName[584:592]:        ExportL2,
+	_MeasurementLowerName[584:592]:   ExportL2,
+	_MeasurementName[592:600]:        ExportL3,
+	_MeasurementLowerName[592:600]:   ExportL3,
+	_MeasurementName[600:611]:        ReactiveSum,
+	_MeasurementLowerName[600:611]:   ReactiveSum,
+	_MeasurementName[611:624]:        ReactiveSumT1,
+	_MeasurementLowerName[611:624]:   ReactiveSumT1,
+	_MeasurementName[624:637]:        ReactiveSumT2,
+	_MeasurementLowerName[624:637]:   ReactiveSumT2,
+	_MeasurementName[637:650]:        ReactiveSumL1,
+	_MeasurementLowerName[637:650]:   ReactiveSumL1,
+	_MeasurementName[650:663]:        ReactiveSumL2,
+	_MeasurementLowerName[650:663]:   ReactiveSumL2,
+	_MeasurementName[663:676]:        ReactiveSumL3,
+	_MeasurementLowerName[663:676]:   ReactiveSumL3,
+	_MeasurementName[676:690]:        ReactiveImport,
+	_MeasurementLowerName[676:690]:   ReactiveImport,
+	_MeasurementName[690:706]:        ReactiveImportT1,
+	_MeasurementLowerName[690:706]:   ReactiveImportT1,
+	_MeasurementName[706:722]:        ReactiveImportT2,
+	_MeasurementLowerName[706:722]:   ReactiveImportT2,
+	_MeasurementName[722:738]:        ReactiveImportL1,
+	_MeasurementLowerName[722:738]:   ReactiveImportL1,
+	_MeasurementName[738:754]:        ReactiveImportL2,
+	_MeasurementLowerName[738:754]:   ReactiveImportL2,
+	_MeasurementName[754:770]:        ReactiveImportL3,
+	_MeasurementLowerName[754:770]:   ReactiveImportL3,
+	_MeasurementName[770:784]:        ReactiveExport,
+	_MeasurementLowerName[770:784]:   ReactiveExport,
+	_MeasurementName[784:800]:        ReactiveExportT1,
+	_MeasurementLowerName[784:800]:   ReactiveExportT1,
+	_MeasurementName[800:816]:        ReactiveExportT2,
+	_MeasurementLowerName[800:816]:   ReactiveExportT2,
+	_MeasurementName[816:832]:        ReactiveExportL1,
+	_MeasurementLowerName[816:832]:   ReactiveExportL1,
+	_MeasurementName[832:848]:        ReactiveExportL2,
+	_MeasurementLowerName[832:848]:   ReactiveExportL2,
+	_MeasurementName[848:864]:        ReactiveExportL3,
+	_MeasurementLowerName[848:864]:   ReactiveExportL3,
+	_MeasurementName[864:873]:        DCCurrent,
+	_MeasurementLowerName[864:873]:   DCCurrent,
+	_MeasurementName[873:882]:        DCVoltage,
+	_MeasurementLowerName[873:882]:   DCVoltage,
+	_MeasurementName[882:889]:        DCPower,
+	_MeasurementLowerName[882:889]:   DCPower,
+	_MeasurementName[889:901]:        HeatSinkTemp,
+	_MeasurementLowerName[889:901]:   HeatSinkTemp,
+	_MeasurementName[901:912]:        DCCurrentS1,
+	_MeasurementLowerName[901:912]:   DCCurrentS1,
+	_MeasurementName[912:923]:        DCVoltageS1,
+	_MeasurementLowerName[912:923]:   DCVoltageS1,
+	_MeasurementName[923:932]:        DCPowerS1,
+	_MeasurementLowerName[923:932]:   DCPowerS1,
+	_MeasurementName[932:942]:        DCEnergyS1,
+	_MeasurementLowerName[932:942]:   DCEnergyS1,
+	_MeasurementName[942:953]:        DCCurrentS2,
+	_MeasurementLowerName[942:953]:   DCCurrentS2,
+	_MeasurementName[953:964]:        DCVoltageS2,
+	_MeasurementLowerName[953:964]:   DCVoltageS2,
+	_MeasurementName[964:973]:        DCPowerS2,
+	_MeasurementLowerName[964:973]:   DCPowerS2,
+	_MeasurementName[973:983]:        DCEnergyS2,
+	_MeasurementLowerName[973:983]:   DCEnergyS2,
+	_MeasurementName[983:994]:        DCCurrentS3,
+	_MeasurementLowerName[983:994]:   DCCurrentS3,
+	_MeasurementName[994:1005]:       DCVoltageS3,
+	_MeasurementLowerName[994:1005]:  DCVoltageS3,
+	_MeasurementName[1005:1014]:      DCPowerS3,
+	_MeasurementLowerName[1005:1014]: DCPowerS3,
+	_MeasurementName[1014:1024]:      DCEnergyS3,
+	_MeasurementLowerName[1014:1024]: DCEnergyS3,
+	_MeasurementName[1024:1035]:      DCCurrentS4,
+	_MeasurementLowerName[1024:1035]: DCCurrentS4,
+	_MeasurementName[1035:1046]:      DCVoltageS4,
+	_MeasurementLowerName[1035:1046]: DCVoltageS4,
+	_MeasurementName[1046:1055]:      DCPowerS4,
+	_MeasurementLowerName[1046:1055]: DCPowerS4,
+	_MeasurementName[1055:1065]:      DCEnergyS4,
+	_MeasurementLowerName[1055:1065]: DCEnergyS4,
+	_MeasurementName[1065:1076]:      ChargeState,
+	_MeasurementLowerName[1065:1076]: ChargeState,
+	_MeasurementName[1076:1090]:      BatteryVoltage,
+	_MeasurementLowerName[1076:1090]: BatteryVoltage,
+	_MeasurementName[1090:1100]:      PhaseAngle,
+	_MeasurementLowerName[1090:1100]: PhaseAngle,
 }
 
 var _MeasurementNames = []string{
 	_MeasurementName[0:9],
-	_MeasurementName[9:16],
-	_MeasurementName[16:25],
-	_MeasurementName[25:34],
-	_MeasurementName[34:43],
-	_MeasurementName[43:50],
-	_MeasurementName[50:59],
-	_MeasurementName[59:68],
-	_MeasurementName[68:77],
-	_MeasurementName[77:82],
-	_MeasurementName[82:89],
-	_MeasurementName[89:96],
-	_MeasurementName[96:103],
-	_MeasurementName[103:114],
-	_MeasurementName[114:127],
-	_MeasurementName[127:140],
-	_MeasurementName[140:153],
-	_MeasurementName[153:164],
-	_MeasurementName[164:177],
-	_MeasurementName[177:190],
-	_MeasurementName[190:203],
-	_MeasurementName[203:216],
-	_MeasurementName[216:231],
-	_MeasurementName[231:246],
-	_MeasurementName[246:261],
+	_MeasurementName[9:20],
+	_MeasurementName[20:31],
+	_MeasurementName[31:42],
+	_MeasurementName[42:49],
+	_MeasurementName[49:58],
+	_MeasurementName[58:67],
+	_MeasurementName[67:76],
+	_MeasurementName[76:83],
+	_MeasurementName[83:92],
+	_MeasurementName[92:101],
+	_MeasurementName[101:110],
+	_MeasurementName[110:122],
+	_MeasurementName[122:134],
+	_MeasurementName[134:146],
+	_MeasurementName[146:160],
+	_MeasurementName[160:174],
+	_MeasurementName[174:179],
+	_MeasurementName[179:186],
+	_MeasurementName[186:193],
+	_MeasurementName[193:200],
+	_MeasurementName[200:211],
+	_MeasurementName[211:224],
+	_MeasurementName[224:237],
+	_MeasurementName[237:250],
+	_MeasurementName[250:261],
 	_MeasurementName[261:274],
-	_MeasurementName[274:289],
-	_MeasurementName[289:304],
-	_MeasurementName[304:319],
-	_MeasurementName[319:325],
-	_MeasurementName[325:333],
-	_MeasurementName[333:341],
-	_MeasurementName[341:349],
-	_MeasurementName[349:352],
-	_MeasurementName[352:357],
-	_MeasurementName[357:362],
-	_MeasurementName[362:367],
-	_MeasurementName[367:370],
-	_MeasurementName[370:375],
-	_MeasurementName[375:380],
-	_MeasurementName[380:385],
-	_MeasurementName[385:390],
-	_MeasurementName[390:395],
-	_MeasurementName[395:401],
-	_MeasurementName[401:409],
-	_MeasurementName[409:417],
-	_MeasurementName[417:425],
-	_MeasurementName[425:433],
-	_MeasurementName[433:441],
-	_MeasurementName[441:447],
-	_MeasurementName[447:455],
-	_MeasurementName[455:463],
-	_MeasurementName[463:471],
-	_MeasurementName[471:479],
-	_MeasurementName[479:487],
-	_MeasurementName[487:498],
-	_MeasurementName[498:511],
-	_MeasurementName[511:524],
-	_MeasurementName[524:537],
-	_MeasurementName[537:550],
-	_MeasurementName[550:563],
-	_MeasurementName[563:577],
-	_MeasurementName[577:593],
-	_MeasurementName[593:609],
-	_MeasurementName[609:625],
-	_MeasurementName[625:641],
-	_MeasurementName[641:657],
-	_MeasurementName[657:671],
-	_MeasurementName[671:687],
-	_MeasurementName[687:703],
-	_MeasurementName[703:719],
-	_MeasurementName[719:735],
-	_MeasurementName[735:751],
-	_MeasurementName[751:760],
-	_MeasurementName[760:769],
-	_MeasurementName[769:776],
-	_MeasurementName[776:788],
-	_MeasurementName[788:799],
-	_MeasurementName[799:810],
-	_MeasurementName[810:819],
-	_MeasurementName[819:829],
-	_MeasurementName[829:840],
-	_MeasurementName[840:851],
-	_MeasurementName[851:860],
-	_MeasurementName[860:870],
-	_MeasurementName[870:881],
-	_MeasurementName[881:892],
-	_MeasurementName[892:901],
-	_MeasurementName[901:911],
-	_MeasurementName[911:922],
-	_MeasurementName[922:933],
-	_MeasurementName[933:942],
-	_MeasurementName[942:952],
-	_MeasurementName[952:963],
-	_MeasurementName[963:977],
-	_MeasurementName[977:987],
+	_MeasurementName[274:287],
+	_MeasurementName[287:300],
+	_MeasurementName[300:313],
+	_MeasurementName[313:328],
+	_MeasurementName[328:343],
+	_MeasurementName[343:358],
+	_MeasurementName[358:371],
+	_MeasurementName[371:386],
+	_MeasurementName[386:401],
+	_MeasurementName[401:416],
+	_MeasurementName[416:422],
+	_MeasurementName[422:430],
+	_MeasurementName[430:438],
+	_MeasurementName[438:446],
+	_MeasurementName[446:449],
+	_MeasurementName[449:454],
+	_MeasurementName[454:459],
+	_MeasurementName[459:464],
+	_MeasurementName[464:480],
+	_MeasurementName[480:483],
+	_MeasurementName[483:488],
+	_MeasurementName[488:493],
+	_MeasurementName[493:498],
+	_MeasurementName[498:503],
+	_MeasurementName[503:508],
+	_MeasurementName[508:514],
+	_MeasurementName[514:522],
+	_MeasurementName[522:530],
+	_MeasurementName[530:538],
+	_MeasurementName[538:546],
+	_MeasurementName[546:554],
+	_MeasurementName[554:560],
+	_MeasurementName[560:568],
+	_MeasurementName[568:576],
+	_MeasurementName[576:584],
+	_MeasurementName[584:592],
+	_MeasurementName[592:600],
+	_MeasurementName[600:611],
+	_MeasurementName[611:624],
+	_MeasurementName[624:637],
+	_MeasurementName[637:650],
+	_MeasurementName[650:663],
+	_MeasurementName[663:676],
+	_MeasurementName[676:690],
+	_MeasurementName[690:706],
+	_MeasurementName[706:722],
+	_MeasurementName[722:738],
+	_MeasurementName[738:754],
+	_MeasurementName[754:770],
+	_MeasurementName[770:784],
+	_MeasurementName[784:800],
+	_MeasurementName[800:816],
+	_MeasurementName[816:832],
+	_MeasurementName[832:848],
+	_MeasurementName[848:864],
+	_MeasurementName[864:873],
+	_MeasurementName[873:882],
+	_MeasurementName[882:889],
+	_MeasurementName[889:901],
+	_MeasurementName[901:912],
+	_MeasurementName[912:923],
+	_MeasurementName[923:932],
+	_MeasurementName[932:942],
+	_MeasurementName[942:953],
+	_MeasurementName[953:964],
+	_MeasurementName[964:973],
+	_MeasurementName[973:983],
+	_MeasurementName[983:994],
+	_MeasurementName[994:1005],
+	_MeasurementName[1005:1014],
+	_MeasurementName[1014:1024],
+	_MeasurementName[1024:1035],
+	_MeasurementName[1035:1046],
+	_MeasurementName[1046:1055],
+	_MeasurementName[1055:1065],
+	_MeasurementName[1065:1076],
+	_MeasurementName[1076:1090],
+	_MeasurementName[1090:1100],
 }
 
 // MeasurementString retrieves an enum value from the enum constants string name.


### PR DESCRIPTION
## Summary
Master is currently red on every CI run since #359. Two fixes:

1. **`meters/measurement_enumer.go` regenerated.** #359 added new `Measurement` enum values (`FrequencyL1/L2/L3`, `VoltageL1_L2`, `VoltageL_N_avg`, `ThreePhase_Vec_A`, …) but didn't run `make assets`, so the auto-generated file was out of sync with `measurements.go`. Build and Lint failed with `invalid argument: index N out of bounds [0:1]`; Clean's porcelain check also flagged the dirty `make assets` output.
2. **Build and Lint jobs now run `make install && make assets` first.** Previously only the Clean job did this; Build/Lint operated directly on tracked sources and would have surfaced this same drift the next time someone forgot `make assets`.

Generated locally with the pinned `github.com/dmarkham/enumer v1.6.3` (from `tools.go` / `go.mod`).

## Test plan
- [ ] Build, Lint, Clean all pass on this PR.
- [ ] After merge: master CI returns to green.
- [ ] Next PR that extends the enum will surface the issue in CI even if the contributor forgets `make assets`.