### PR TITLE
chore: upgrade gosunspec

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -16,7 +16,7 @@ import (
 	sunspec "github.com/andig/gosunspec"
 	bus "github.com/andig/gosunspec/modbus"
 	_ "github.com/andig/gosunspec/models" // import models
-	"github.com/andig/gosunspec/smdx"
+	"github.com/andig/gosunspec/types"
 )
 
 // inspectCmd represents the inspect command
@@ -104,14 +104,14 @@ func scanSunspec(client modbus.Client) {
 }
 
 func modelName(m sunspec.Model) string {
-	model := smdx.GetModel(uint16(m.Id()))
+	model := types.GetModel(uint16(m.Id()))
 	if model == nil {
 		return ""
 	}
 	return model.Name
 }
 
-func printModel(m *smdx.ModelElement) {
+func printModel(m *types.Model) {
 	pf("-- Definition --")
 	// pf("----")
 	// pf("Model:  %d - %s", m.Id, m.Name)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/volkszaehler/mbmd
 go 1.24.1
 
 require (
-	github.com/andig/gosunspec v0.0.0-20240918203654-860ce51d602b
+	github.com/andig/gosunspec v0.0.0-20260523125438-3accc276abc0
 	github.com/dmarkham/enumer v1.6.3
 	github.com/eclipse/paho.mqtt.golang v1.5.1
 	github.com/gorilla/handlers v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
-github.com/andig/gosunspec v0.0.0-20240918203654-860ce51d602b h1:81UMfM949I7StrRay7YDUZazY8M1u/JHkzwcFEjiilQ=
-github.com/andig/gosunspec v0.0.0-20240918203654-860ce51d602b/go.mod h1:c6P6szcR+ROkqZruOR4f6qbDKFjZX6OitPpj+yJ/r8k=
+github.com/andig/gosunspec v0.0.0-20260523125438-3accc276abc0 h1:i34M/0yMHLaDJP6CQ3KMpeKVD+n9XrV5nPb3tdMKFF8=
+github.com/andig/gosunspec v0.0.0-20260523125438-3accc276abc0/go.mod h1:c6P6szcR+ROkqZruOR4f6qbDKFjZX6OitPpj+yJ/r8k=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=


### PR DESCRIPTION
## Summary
Bumps `github.com/andig/gosunspec` to `v0.0.0-20260523125438-3accc276abc0` (from the 2024-09-18 pseudo-version).

The new version removes the `smdx` package and moves `GetModel`/`ModelElement` into the `types` package. Migrated `cmd/inspect.go`:
- import `gosunspec/smdx` → `gosunspec/types`
- `smdx.GetModel(...)` → `types.GetModel(...)`
- `*smdx.ModelElement` → `*types.Model`

The `types.Model`/`Block`/`Point` struct field names are identical to the old `smdx` structs, so `printModel` needed no further changes. Model definitions still self-register into the `types` registry via each `models/modelNNN` `init()`, so `GetModel` resolves correctly. The other consumers (`meters/sunspec`) use the `models/*` and `modbus` packages, which were unaffected.

## Verification
- `go build ./...` ✓
- `go vet ./...` ✓
- `go test ./...` ✓
- `go mod tidy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)