### PR TITLE
Janitza: fix energy register scale (from Wh to kWh)

### DIFF
--- a/meters/rs485/janitza.go
+++ b/meters/rs485/janitza.go
@@ -70,16 +70,13 @@ func (p *JanitzaProducer) Probe() Operation {
 
 // Produce implements Producer interface
 func (p *JanitzaProducer) Produce() (res []Operation) {
-	// energy registers report Wh and need scaling to kWh
-	energy := map[Measurement]bool{
-		ImportL1: true, ImportL2: true, ImportL3: true, Import: true,
-		ExportL1: true, ExportL2: true, ExportL3: true, Export: true,
-	}
-
 	for op := range p.Opcodes {
-		if energy[op] {
+		switch op {
+		case ImportL1, ImportL2, ImportL3, Import,
+			ExportL1, ExportL2, ExportL3, Export:
+			// energy registers report Wh
 			res = append(res, p.snip(op, 1000)) // Wh -> kWh
-		} else {
+		default:
 			res = append(res, p.snip(op))
 		}
 	}

--- a/meters/rs485/janitza.go
+++ b/meters/rs485/janitza.go
@@ -47,13 +47,18 @@ func (p *JanitzaProducer) Description() string {
 	return "Janitza B-Series meters"
 }
 
-func (p *JanitzaProducer) snip(iec Measurement) Operation {
+func (p *JanitzaProducer) snip(iec Measurement, scaler ...float64) Operation {
+	transform := RTUIeee754ToFloat64 // default conversion
+	if len(scaler) > 0 {
+		transform = MakeScaledTransform(transform, scaler[0])
+	}
+
 	snip := Operation{
 		FuncCode:  ReadHoldingReg,
 		OpCode:    p.Opcode(iec),
 		ReadLen:   2,
 		IEC61850:  iec,
-		Transform: RTUIeee754ToFloat64,
+		Transform: transform,
 	}
 	return snip
 }
@@ -65,8 +70,18 @@ func (p *JanitzaProducer) Probe() Operation {
 
 // Produce implements Producer interface
 func (p *JanitzaProducer) Produce() (res []Operation) {
+	// energy registers report Wh and need scaling to kWh
+	energy := map[Measurement]bool{
+		ImportL1: true, ImportL2: true, ImportL3: true, Import: true,
+		ExportL1: true, ExportL2: true, ExportL3: true, Export: true,
+	}
+
 	for op := range p.Opcodes {
-		res = append(res, p.snip(op))
+		if energy[op] {
+			res = append(res, p.snip(op, 1000)) // Wh -> kWh
+		} else {
+			res = append(res, p.snip(op))
+		}
 	}
 
 	return res


### PR DESCRIPTION
Janitza energy readings are a factor of 1000 too high (reported via [evcc-io/evcc#30671](https://github.com/evcc-io/evcc/issues/30671), affecting a UMG604-E).

Applys a `1000` scaler fix to the energy opcodes only (`Import*`/`Export*`).
Voltage/current/power/frequency/power-factor stay in their base units (V/A/W/Hz/-) and are unchanged.

Verified register addresses and units against the B-Series manual (`janitza-bhb-b2x-en.pdf`).

Fix https://github.com/evcc-io/evcc/issues/30671